### PR TITLE
Fix GitHub Actions build step for SvelteKit v2

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,7 +65,7 @@ jobs:
         run: bunx svelte-kit sync
 
       - name: Build SvelteKit server
-        run: bunx svelte-kit build
+        run: bunx vite build
 
       - name: Start preview server (port 4173)
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Start preview server (port 4173)
         run: |
-          bunx svelte-kit preview --port 4173 --host 127.0.0.1 > preview.log 2>&1 &
+          bunx vite preview --port 4173 --host 127.0.0.1 > preview.log 2>&1 &
           echo $! > preview.pid
 
       - name: Wait for server to be ready


### PR DESCRIPTION
This PR updates the CI workflow to use vite build instead of svelte-kit build, ensuring compatibility with SvelteKit v2 and allowing the workflow to complete successfully.