### PR TITLE
Fix Playwright test step in GitHub Actions workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Run Playwright tests
         run: |
           mkdir -p test-results/playwright
-          bunx playwright test tests/playwright --workers 8 --output=test-results/playwright
+          npx playwright test --workers 8 --output-dir=test-results/playwright
 
       - name: Run Bun tests (after server is up)
         env:


### PR DESCRIPTION
This PR updates the Playwright test command in the CI workflow to use npx playwright test with --output-dir instead of bunx and the deprecated --output flag. This ensures Playwright tests run reliably and results are stored correctly during CI runs.