### PR TITLE
Update playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,83 +1,45 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test'
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
-	testDir: './tests',
-	/* Run tests in files in parallel */
-	fullyParallel: true,
-	/* Fail the build on CI if you accidentally left test.only in the source code. */
-	forbidOnly: !!process.env.CI,
-	/* Retry on CI only */
-	retries: process.env.CI ? 2 : 0,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
-	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	//reporter: 'html',
-	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-	use: {
-		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:5173',
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
 
-		launchOptions: {
-			slowMo: parseInt(process.env.SLOW_MO || '0')
-		},
+  /* Reporter to use. You can enable HTML if needed */
+  // reporter: 'html',
 
-		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
-		video: 'retain-on-failure'
-	},
+  use: {
+    /* Base URL comes from workflow or local fallback */
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173',
 
-	/* Configure projects for major browsers */
-	projects: [
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] }
-		},
+    launchOptions: {
+      slowMo: parseInt(process.env.SLOW_MO || '0')
+    },
 
-		{
-			name: 'firefox',
-			use: { ...devices['Desktop Firefox'] }
-		},
+    /* Collect trace when retrying the failed test. */
+    trace: 'on-first-retry',
+    video: 'retain-on-failure'
+  },
 
-		{
-			name: 'webkit',
-			use: { ...devices['Desktop Safari'] }
-		},
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
 
-		/* Test against mobile viewports. */
-		{
-			name: 'Mobile Chrome',
-			use: { ...devices['Pixel 5'] }
-		},
-		{
-			name: 'Mobile Safari',
-			use: { ...devices['iPhone 12'] }
-		},
+    // Mobile
+    { name: 'Mobile Chrome', use: { ...devices['Pixel 5'] } },
+    { name: 'Mobile Safari', use: { ...devices['iPhone 12'] } },
 
-		/* Test against branded browsers. */
-		{
-			name: 'Microsoft Edge',
-			use: { ...devices['Desktop Edge'], channel: 'msedge' }
-		},
-		{
-			name: 'Google Chrome',
-			use: { ...devices['Desktop Chrome'], channel: 'chrome' }
-		}
-	],
+    // Branded browsers
+    { name: 'Microsoft Edge', use: { ...devices['Desktop Edge'], channel: 'msedge' } },
+    { name: 'Google Chrome', use: { ...devices['Desktop Chrome'], channel: 'chrome' } }
+  ]
 
-	/* Run your local dev server before starting the tests */
-	webServer: {
-		command: process.env.CI ? 'bun run build && bun run preview' : 'bun run dev',
-		port: process.env.CI ? 4173 : 5173,
-		timeout: 240000, // Timeout in milliseconds
-		reuseExistingServer: !process.env.CI
-	}
-});
+  // 🚨 Removed webServer block — server is managed by GitHub Actions workflow
+})


### PR DESCRIPTION
This PR updates the Playwright workflow to support both development and preview (build) modes. It ensures the correct server is started for tests and avoids connection issues (e.g., Playwright expecting :5173 while preview runs on :4173).