### PR TITLE
fix: CI check job and E2E stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,20 @@ jobs:
           PLAYWRIGHT_TEST_BASE_URL: http://127.0.0.1:4173
         run: |
           bun run preview --host 127.0.0.1 > preview.log 2>&1 &
-          for i in $(seq 1 60); do curl -sf http://127.0.0.1:4173/api/system/health > /dev/null 2>&1 && break; sleep 1; done
+          SERVER_PID=$!
+          SERVER_READY=false
+          for i in $(seq 1 60); do
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "::error::Preview server crashed"; cat preview.log; exit 1
+            fi
+            if curl -sf http://127.0.0.1:4173/api/system/health > /dev/null 2>&1; then
+              SERVER_READY=true; break
+            fi
+            sleep 1
+          done
+          if [ "$SERVER_READY" != "true" ]; then
+            echo "::error::Server not ready after 60s"; cat preview.log; exit 1
+          fi
           bun run scripts/setup-system.ts
           sleep 3
           bun x playwright test --project=chromium --shard=${{ matrix.shard }}/3
@@ -434,7 +447,20 @@ jobs:
           TEST_MODE: true
         run: |
           bun run preview --host 127.0.0.1 > preview.log 2>&1 &
-          for i in $(seq 1 60); do curl -sf http://127.0.0.1:4173/api/system/health > /dev/null 2>&1 && break; sleep 1; done
+          SERVER_PID=$!
+          SERVER_READY=false
+          for i in $(seq 1 60); do
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "::error::Preview server crashed"; cat preview.log; exit 1
+            fi
+            if curl -sf http://127.0.0.1:4173/api/system/health > /dev/null 2>&1; then
+              SERVER_READY=true; break
+            fi
+            sleep 1
+          done
+          if [ "$SERVER_READY" != "true" ]; then
+            echo "::error::Server not ready after 60s"; cat preview.log; exit 1
+          fi
           bun run scripts/setup-system.ts
 
       - name: Run Hooks Benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,19 +124,6 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
       - run: bun install --frozen-lockfile --prefer-offline --cache-dir .bun-cache
-      
-      - name: Run System Setup (Real Black-Box)
-        env:
-          DB_TYPE: sqlite
-          TEST_MODE: true
-        run: |
-          # Start server in background
-          bun run preview --port 4173 --host 127.0.0.1 > preview.log 2>&1 &
-          # Wait for server health
-          bun x wait-on http://127.0.0.1:4173/api/system/health --timeout 60000
-          # Run system setup via API
-          bun run scripts/setup-system.ts
-          
       - run: bun run check
 
   unit-vitest:
@@ -354,7 +341,7 @@ jobs:
     name: 🎭 E2E (shard ${{ matrix.shard }})
     needs: [bootstrap, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     strategy:
       fail-fast: false
@@ -397,23 +384,19 @@ jobs:
           TEST_MODE: true
           PLAYWRIGHT_TEST_BASE_URL: http://127.0.0.1:4173
         run: |
-          # Start server in background
-          bun run preview --port 4173 --host 127.0.0.1 > preview.log 2>&1 &
-
-          # Wait for server health
-          bun x wait-on http://127.0.0.1:4173/api/system/health --timeout 60000
-
-          # Run system setup via API
+          bun run preview --host 127.0.0.1 > preview.log 2>&1 &
+          for i in $(seq 1 60); do curl -sf http://127.0.0.1:4173/api/system/health > /dev/null 2>&1 && break; sleep 1; done
           bun run scripts/setup-system.ts
-
-          # Run Playwright tests
+          sleep 3
           bun x playwright test --project=chromium --shard=${{ matrix.shard }}/3
 
       - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report-${{ matrix.shard }}
-          path: playwright-report
+          path: |
+            playwright-report
+            preview.log
 
   # ------------------------------------------------
   # 7. Performance Benchmarks
@@ -450,11 +433,8 @@ jobs:
           DB_TYPE: sqlite
           TEST_MODE: true
         run: |
-          # Start server in background
-          bun run preview --port 4173 --host 127.0.0.1 > preview.log 2>&1 &
-          # Wait for server health
-          bun x wait-on http://127.0.0.1:4173/api/system/health --timeout 60000
-          # Run system setup via API
+          bun run preview --host 127.0.0.1 > preview.log 2>&1 &
+          for i in $(seq 1 60); do curl -sf http://127.0.0.1:4173/api/system/health > /dev/null 2>&1 && break; sleep 1; done
           bun run scripts/setup-system.ts
 
       - name: Run Hooks Benchmark

--- a/scripts/setup-system.ts
+++ b/scripts/setup-system.ts
@@ -45,18 +45,25 @@ function parseActionResult(result: any): any {
 }
 
 async function postAction(actionName: string, formData: FormData) {
-	const res = await fetch(`${API_BASE_URL}/setup?/${actionName}`, {
-		method: 'POST',
-		body: formData,
-		headers: {
-			'x-sveltekit-action': 'true',
-			Origin: API_BASE_URL
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 30_000);
+	try {
+		const res = await fetch(`${API_BASE_URL}/setup?/${actionName}`, {
+			method: 'POST',
+			body: formData,
+			signal: controller.signal,
+			headers: {
+				'x-sveltekit-action': 'true',
+				Origin: API_BASE_URL
+			}
+		});
+		if (!res.ok) {
+			throw new Error(`Action ${actionName} failed with status ${res.status}`);
 		}
-	});
-	if (!res.ok) {
-		throw new Error(`Action ${actionName} failed with status ${res.status}`);
+		return await res.json();
+	} finally {
+		clearTimeout(timeout);
 	}
-	return await res.json();
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- **check job**: Removed server startup step that was failing (no build artifact available, type checking doesn't need a running server)
- **E2E**: Replaced `wait-on` with `curl` polling for more reliable server health checks, added `sleep 3` after setup for config propagation, bumped shard timeout to 25 min, included `preview.log` in artifacts
- **benchmarks**: Replaced `wait-on` with `curl` polling

## Context
Built on top of `ce32070a`. The `check` job was failing because it tried to start a preview server without downloading the `build-output` artifact — `vite preview` needs the built output to serve.

## Test plan
- [ ] `check` job passes without server startup
- [ ] E2E shards start and run tests successfully
- [ ] Benchmark job server setup works