### PR TITLE
fix(auth): repair first-run and login flow on fresh installs

### DIFF
--- a/src/databases/auth/index.ts
+++ b/src/databases/auth/index.ts
@@ -305,7 +305,9 @@ export class Auth {
     if (result?.success) {
       return result.data;
     }
-    return 0;
+    // Return -1 ("unknown"), NOT 0, on failure: a failed/early read must not be
+    // mistaken for a genuine empty database (which would force the first-user/sign-up flow).
+    return -1;
   }
 
   async createSession(

--- a/src/hooks/handle-authorization.ts
+++ b/src/hooks/handle-authorization.ts
@@ -92,6 +92,12 @@ async function getCachedUserCount(
       ? { bypassTenantCheck: true }
       : { tenantId: tenantId as DatabaseId };
     const count = await auth.getUserCount(filter, bypassOpts);
+    // Never cache a non-authoritative count. A negative value means the read failed or auth
+    // wasn't ready; caching it (TTL = 1h) would pin a false "fresh install" state and break
+    // login until the TTL expires. Return it uncached so the next request re-reads.
+    if (count < 0) {
+      return count;
+    }
     const cacheData = { count, timestamp: now };
     userCountCache = cacheData;
     await cacheService.set(

--- a/src/routes/setup/setup.server.ts
+++ b/src/routes/setup/setup.server.ts
@@ -342,6 +342,15 @@ export async function completeSetup(
   const { invalidateSetupCache } = await import("@src/utils/setup-check");
   invalidateSetupCache(true);
 
+  // The admin now exists — clear the cached user count (TTL 1h) so the login page
+  // immediately sees a non-empty DB and offers Sign In instead of the first-user Sign Up.
+  try {
+    const { invalidateUserCountCache } = await import("@src/hooks/handle-authorization");
+    await invalidateUserCountCache();
+  } catch {
+    // Non-fatal: cache will self-heal on next authoritative read.
+  }
+
   // Determine redirect target — first collection if seeded, otherwise builder
   let redirectPath = "/config/collectionbuilder";
   try {

--- a/src/routes/setup/write-private-config.ts
+++ b/src/routes/setup/write-private-config.ts
@@ -133,16 +133,16 @@ export const privateEnv = {
         // SQLite uses file paths not network hosts — skip exact match to avoid
         // Windows/Unix path separator mismatch (backslash vs forward slash).
         regex: dbConfig.type === "sqlite"
-          ? /\bDB_HOST\s*:\\s*['"][^'"]*['"]/
+          ? /\bDB_HOST\s*:\s*['"][^'"]*['"]/
           : dbConfig.host
             ? new RegExp(`\\bDB_HOST\\s*:\\s*['"]${escape(dbConfig.host)}['"]`)
-            : /\bDB_HOST\s*:\\s*['"]['"]/,
+            : /\bDB_HOST\s*:\s*['"]['"]/,
       },
       {
         name: "DB_NAME",
         regex: dbConfig.name
           ? new RegExp(`\\bDB_NAME\\s*:\\s*['"]${escape(dbConfig.name)}['"]`)
-          : /\bDB_NAME\\s*:\\s*['"][^'"]*['"]/,
+          : /\bDB_NAME\s*:\s*['"][^'"]*['"]/,
       },
       {
         name: "DB_TYPE",


### PR DESCRIPTION
## fix(auth): repair first-run and login flow on fresh installs

### Problem
On a clean install (verified with SQLite) you can complete the setup wizard, but afterwards
**the login page only ever shows "Sign Up" and you cannot sign in** — and the default roles are
never seeded. This very likely also explains the failing E2E setup-wizard tests.

### Root causes & fixes (4 small changes)
1. **`src/routes/setup/write-private-config.ts`** — the SQLite `DB_HOST`/`DB_NAME` validation
   used regex **literals** containing `\\s` (a literal backslash + `s`) instead of `\s`, so the
   check could never match and threw *“Failed to write private configuration: DB_HOST.”* The
   config file was actually written fine, but the thrown error **aborted setup before roles were
   seeded.** Fixed the three regex literals.
2. **`src/databases/auth/index.ts`** — `getUserCount()` returned `0` on any non-`success` result,
   making a failed/early read indistinguishable from a genuinely empty DB. Now returns `-1`
   (“unknown”) on failure.
3. **`src/hooks/handle-authorization.ts`** — `getCachedUserCount()` cached every result for 1h.
   A transient `0` read during the multi-second DB boot got pinned, so `firstUserExists` stayed
   `false` and login only offered Sign Up. Now skips caching a negative (non-authoritative) count.
4. **`src/routes/setup/setup.server.ts`** — invalidate the user-count cache right after the admin
   is created, so the login page immediately sees a non-empty database.

### Verification
On a fresh SQLite install: setup completes, **roles are seeded (3)**, the **Sign In form is
reachable**, and the admin logs in successfully; `/dashboard` then persists.
- `bun run check`: 3737 files, 0 errors, 0 warnings · `bun run lint`: pass · `bun run test`: 334 pass.

### Scope
4 files, +21/−4. No formatting churn, no unrelated changes. Independent of the styling PR.

### Checklist
- [x] `bun run check` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes
- [x] Minimal, focused diff
- [x] Manually verified the fresh-install login flow
