### PR TITLE
fix(settings): load groups, remove duplicate boolean label, fix false unsaved-changes prompt

### DIFF
--- a/src/routes/(app)/config/system-settings/generic-settings-group.svelte
+++ b/src/routes/(app)/config/system-settings/generic-settings-group.svelte
@@ -64,11 +64,16 @@ let originalValues = $state<Record<string, unknown>>({}); // Track original valu
 let errors = $state<Record<string, string>>({});
 let hasEmptyRequiredFields = $state(false);
 
-// Optimize: Use $derived instead of $effect for unsaved changes
+// Optimize: Use $derived instead of $effect for unsaved changes.
+// Guard on !loading && !error: while loading or after a failed load, `originalValues` is not
+// populated, yet `bind:value` inputs (e.g. <select>) auto-fill defaults into `values` — which
+// would otherwise look like unsaved edits and trigger a false "unsaved changes" navigation prompt.
 let hasUnsavedChanges = $derived(
-	Object.keys(values).some((key) => {
-		return JSON.stringify(values[key]) !== JSON.stringify(originalValues[key]);
-	}),
+	!loading &&
+		!error &&
+		Object.keys(values).some((key) => {
+			return JSON.stringify(values[key]) !== JSON.stringify(originalValues[key]);
+		}),
 );
 
 // Notify parent component when hasUnsavedChanges changes

--- a/src/routes/(app)/config/system-settings/generic-settings-group.svelte
+++ b/src/routes/(app)/config/system-settings/generic-settings-group.svelte
@@ -1181,7 +1181,7 @@ onMount(() => {
 											}
 										}}
 									/>
-									<span>{field.label}</span>
+									<!-- label already shown by the field header above (avoids duplicate) -->
 								</label>
 								<!-- Select Input -->
 							{:else if field.type === 'select' && field.options}

--- a/src/routes/(app)/config/system-settings/settings.remote.ts
+++ b/src/routes/(app)/config/system-settings/settings.remote.ts
@@ -6,7 +6,7 @@
  * Wraps the REST API with typed functions.
  */
 
-import { query } from "$app/server";
+import { query, getRequestEvent } from "$app/server";
 
 export const loadSettingsGroup = query(
   "unchecked",
@@ -17,6 +17,9 @@ export const loadSettingsGroup = query(
     groupId: string;
     bypassCache?: boolean;
   }): Promise<{ success: boolean; values?: Record<string, unknown>; error?: string }> => {
+    // Use the request event's fetch: remote functions run on the server, where the global
+    // fetch rejects relative URLs. event.fetch resolves them against the current request.
+    const { fetch } = getRequestEvent();
     const url = bypassCache ? `/api/settings/${groupId}?refresh=true` : `/api/settings/${groupId}`;
     const r = await fetch(url);
     const d = await r.json();
@@ -40,6 +43,7 @@ export const saveSettingsGroup = query(
     message?: string;
     error?: string;
   }> => {
+    const { fetch } = getRequestEvent();
     const r = await fetch(`/api/settings/${groupId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -55,6 +59,7 @@ export const saveSettingsGroup = query(
 export const resetSettingsGroup = query(
   "unchecked",
   async (groupId: string): Promise<{ success: boolean; message?: string; error?: string }> => {
+    const { fetch } = getRequestEvent();
     const r = await fetch(`/api/settings/${groupId}`, { method: "DELETE" });
     const d = await r.json();
     return d.success
@@ -66,6 +71,7 @@ export const resetSettingsGroup = query(
 export const loadAllSettings = query(
   "unchecked",
   async (): Promise<{ success: boolean; values?: Record<string, unknown>; error?: string }> => {
+    const { fetch } = getRequestEvent();
     const r = await fetch("/api/settings/all");
     const d = await r.json();
     return d.success


### PR DESCRIPTION
## fix(settings): load System Settings groups and remove duplicate boolean label

Fixes two issues on the **System Settings** page (`/config/system-settings`).

### 1. "Failed to load settings" (500)
The settings remote functions in `settings.remote.ts` call the **global `fetch()` with a
relative URL** (`/api/settings/<group>`). Remote functions execute on the server, where the
global fetch rejects relative URLs:

```
Error: Cannot use relative URL (/api/settings/appearance) with global fetch — use `event.fetch` instead
```

This threw a 500, surfaced in the UI as *"Failed to load settings"* on every group.
**Fix:** use the request event's fetch via `getRequestEvent().fetch` (the same pattern already
used in `collectionbuilder.remote.ts`, `auth.remote.ts`, and `setup.remote.ts`), which resolves
relative URLs against the current request. Applied to all four functions
(load / save / reset / loadAll).

### 2. Duplicate label on boolean settings
Boolean fields rendered their label **twice**: once in the shared field header
(`<label for={field.key}>` — already associated with the checkbox) and again as an inline
`<span>{field.label}</span>` beside the checkbox (e.g. "Enable Seasonal Themes" appeared twice).
**Fix:** removed the redundant inline label; the header label already names the control.

### 3. Spurious "unsaved changes" prompt
The unsaved-changes guard compares `values` to a snapshot `originalValues`. When a group failed
to load (issue #1 above) or while loading, `originalValues` was empty while `bind:value` inputs
(e.g. `<select>`) auto-filled defaults into `values` — which looked like unsaved edits and threw
a "unsaved changes" navigation/`beforeunload` prompt on every leave. **Fix:** gate
`hasUnsavedChanges` on `!loading && !error` so the page is only dirty after a successful load.
(Fixing #1 already removes the trigger; this hardens it against any future load error.)

### Verification
On a fresh SQLite install: the Appearance & Themes group loads with **no error**,
"Enable Seasonal Themes" appears **once**, and navigating away no longer shows a false
"unsaved changes" prompt. `bun run check`: 3737 files, 0 errors.

### Scope
2 files, 2 commits. Independent of the styling (#410) and first-run/login (#411) PRs.

### Checklist
- [x] `bun run check` passes
- [x] Reproduced and verified the fix live (fresh SQLite, logged in)
- [x] Minimal, focused diff; follows existing remote-function pattern
