### PR TITLE
docs(style-guide): standardize page headers on the PageTitle component

### DIFF
--- a/docs/contributing/style-guide-gui.mdx
+++ b/docs/contributing/style-guide-gui.mdx
@@ -325,27 +325,30 @@ This provides the unified full-height scrollable container with theme-aware back
 
 ### Page Header
 
-Every page header uses this exact pattern:
+Every page header uses the shared **`PageTitle`** component (`@components/page-title.svelte`).
+Do NOT hand-roll an inline `<h1>` header — `PageTitle` gives every page the same title size,
+icon treatment, subtitle, responsive truncation, sidebar toggle, accessibility (ARIA live
+region) and action-button slot, so all pages look and behave identically.
 
 ```svelte
-<div class="flex items-center justify-between" in:fade>
-  <div>
-    <h1 class="text-3xl font-bold flex items-center gap-3">
-      <iconify-icon icon="mdi:icon-name" class="text-primary-500"></iconify-icon>
-      Page Title
-    </h1>
-    <p class="text-sm opacity-50 font-medium">Descriptive subtitle</p>
-  </div>
-  <!-- Optional: status badge, action button group -->
-</div>
+<script>
+  import PageTitle from '@components/page-title.svelte';
+</script>
+
+<PageTitle name="Page Title" icon="mdi:icon-name" description="Descriptive subtitle">
+  <!-- Optional action buttons (rendered on the right) -->
+  <Button variant="primary" leadingIcon="mdi:plus">Create New</Button>
+</PageTitle>
 ```
 
 **Rules**:
 
-- `<h1>` always uses `text-3xl font-bold flex items-center gap-3`
-- Always include a leading icon with `class="text-primary-500"`
-- Subtitle uses `text-sm opacity-50 font-medium`
-- Action buttons go in the right side of the flex container
+- Use `<PageTitle>` for every page header — never an inline `<h1 class="text-3xl …">`.
+- `name` = title; `icon` = leading icon (defaults to `text-tertiary-500 dark:text-primary-500`,
+  i.e. blue in light mode / green in dark — keep this default unless there's a reason not to).
+- `description` = optional subtitle (renders as `text-sm font-medium opacity-50`).
+- Action buttons go in the default slot (children) — they render on the right.
+- Use `highlight` to emphasise part of the title, and `showBackButton`/`backUrl` for back nav.
 
 ### Content Cards
 
@@ -423,20 +426,13 @@ card p-6 border border-surface-200 dark:border-surface-800 bg-white dark:bg-surf
 
 <div class="absolute inset-0 p-6 space-y-8 bg-surface-50/50 dark:bg-surface-950/50 overflow-y-auto">
   <!-- Header -->
-  <div class="flex items-center justify-between" in:fade>
-    <div>
-      <h1 class="text-3xl font-bold flex items-center gap-3">
-        <iconify-icon icon="mdi:icon-name" class="text-primary-500"></iconify-icon>
-        Page Title
-      </h1>
-      <p class="text-sm opacity-50 font-medium">Page description</p>
-    </div>
-    <div class="flex items-center gap-2">
+  <div in:fade>
+    <PageTitle name="Page Title" icon="mdi:icon-name" description="Page description">
       <button class="btn btn-sm preset-filled-primary-500" onclick={handleCreate}>
         <iconify-icon icon="mdi:plus" class="mr-1"></iconify-icon>
         Create New
       </button>
-    </div>
+    </PageTitle>
   </div>
 
   <!-- Content Card -->
@@ -458,7 +454,7 @@ card p-6 border border-surface-200 dark:border-surface-800 bg-white dark:bg-surf
 ### Anti-Patterns (DO NOT USE)
 
 - ❌ `container mx-auto p-4` — use `absolute inset-0 p-6`
-- ❌ `<PageTitle>` component — use inline header per the standard above
+- ❌ Inline `<h1 class="text-3xl font-bold …">` page header — use the `<PageTitle>` component
 - ❌ `h1 text-primary-500` — never hardcode colors on headings
 - ❌ Bare `<div>` content sections — always wrap in a card
 - ❌ `table-container` / `table-hover` classes — use the native table pattern

--- a/src/components/page-title.svelte
+++ b/src/components/page-title.svelte
@@ -54,6 +54,7 @@
 	interface Props {
 		backUrl?: string;
 		children?: import('svelte').Snippet; // For action buttons
+		description?: string; // Optional subtitle shown under the title
 		highlight?: string;
 		icon?: string;
 		iconColor?: string;
@@ -66,6 +67,7 @@
 
 	const {
 		name,
+		description = '',
 		highlight = '',
 		icon,
 		iconColor = 'text-tertiary-500 dark:text-primary-500',
@@ -118,8 +120,9 @@
 				<iconify-icon icon="mingcute:menu-fill" width="24"></iconify-icon>
 			</button>
 		{/if}
+		<div class="ml-2 min-w-0">
 		<h1
-			class="transition-max-width h1 relative ml-2 flex items-center gap-1 font-bold"
+			class="transition-max-width h1 relative flex items-center gap-1 font-bold"
 			style="font-size: clamp(1.5rem, 3vw + 1rem, 2.25rem);"
 			aria-live="polite"
 			data-cms-field="pageTitle"
@@ -137,6 +140,10 @@
 
 			<span class="sr-only absolute inset-0 overflow-hidden whitespace-normal"> {name} </span>
 		</h1>
+		{#if description}
+			<p class="text-sm font-medium opacity-50">{description}</p>
+		{/if}
+		</div>
 	</div>
 
 	<div class="flex flex-wrap items-center gap-2 shrink-0">


### PR DESCRIPTION
## docs(style-guide): standardize page headers on the PageTitle component

Establishes **`<PageTitle>`** as the single canonical page header and documents it.

### Why
The style guide prescribed a hand-rolled inline `<h1 class="text-3xl …">` header and listed
`<PageTitle>` as an *anti-pattern* — but in practice ~**31 pages already use `<PageTitle>`** and
only ~8 use the inline header. The guidance was backwards. One component = consistent title size,
icon treatment, subtitle, responsive truncation, sidebar toggle, accessibility (ARIA live region)
and an action-button slot, so pages look and behave the same.

### Changes
- **`page-title.svelte`** — add an optional **`description`** (subtitle) prop, rendered as
  `text-sm font-medium opacity-50` beneath the title, making the component a full superset of the
  inline header (title + icon + subtitle + right-side action slot). Existing call sites are
  unaffected — the prop is optional and layout is unchanged when it's absent.
  - Note: `PageTitle`'s icon already defaults to `text-tertiary-500 dark:text-primary-500`
    (blue in light / green in dark), matching the agreed colour direction.
- **`style-guide-gui.mdx`** — the *Page Header* section and *Full Page Template* now use
  `<PageTitle>`; the inline `<h1>` header is moved to the anti-pattern list.

### Follow-up (separate, verified)
Migrating the ~8 remaining inline-header pages (config/automations, extensions, queue, redirects,
system-settings, trash, webhooks, webhooks/logs) to `<PageTitle>` will land in the
animation/layout consistency pass, verified in-app in light + dark. (importer/sync are excluded —
they're slated to move into the import/export/sync plugin.)

### Verification
`bun run check`: 3737 files, 0 errors, 0 warnings. Component change is additive; the 31 existing
`<PageTitle>` usages render unchanged.
