### PR TITLE
fix(dashboard): resolve 500 from wrong preferences endpoint + unguarded roles

### DIFF
--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -104,7 +104,9 @@ export const load: PageServerLoad = async ({ locals }) => {
     throw redirect(301, "/login");
   }
 
-  // Check if user has permission to access dashboard
+  // Check if user has permission to access dashboard.
+  // Guard tenantRoles: locals.roles can be undefined (e.g. roles not yet loaded), and calling
+  // .some() on undefined would 500 the whole dashboard instead of doing a clean permission check.
   const hasDashboardPermission =
     isAdmin ||
     (tenantRoles ?? []).some((role) =>


### PR DESCRIPTION
## fix(dashboard): resolve 500 from wrong preferences endpoint + unguarded roles

Visiting **`/dashboard` returned a 500** ("Internal Error" page). Two independent causes:

### 1. Saved-layout fetch hit a dead API namespace
`stores/system-preferences.svelte.ts` had a casing mismatch between its two calls:
- `fetchLayout()` → `GET /api/systemPreferences` (camelCase) ❌
- `saveLayout()` → `POST /api/system-preferences` (kebab-case) ✅

The registered namespace is **`system-preferences`** (kebab-case, see `NAMESPACE_CONFIG` in
`api/[...path]/+server.ts`). The camelCase GET resolved to *"API Namespace not found"* (404), so
the dashboard layout could never load. **Fix:** repoint the GET to `/api/system-preferences`.

### 2. Permission check crashed on undefined roles
`routes/(app)/dashboard/+page.server.ts` did `tenantRoles.some(...)`, but `locals.roles` can be
`undefined` (e.g. roles not yet loaded) → `TypeError: Cannot read properties of undefined
(reading 'some')` → 500 for the whole page. **Fix:** `(tenantRoles ?? []).some(...)` so it
degrades to a clean permission check.

### Verification
Verified in-app on a fresh SQLite install (logged in): `/dashboard` no longer 500s — the page
title is "SveltyCMS" (was "500 - Page Not Found"), and the preferences API now resolves and
correctly returns a 404 for a user with no saved layout (the store handles this as "use
default"). Console settles to 0 errors. `bun run check`: 3737 files, 0 errors.

### Scope
2 files, +5/−3. Part of the broader effort to repair the `next` branch after the performance
refactor severed some endpoints/loads (cf. #411 setup/login, #412 settings). Independent of the
styling PRs.
