### PR TITLE
fix: restore next boot (relational module imports) + fix E2E baseURL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,6 +442,9 @@ jobs:
           bun x wait-on tcp:127.0.0.1:4173 --timeout 180000 --interval 2000 || (cat preview.log && exit 1)
 
           # Run the consolidated Wizard suite
+          # baseURL must point at the CI preview server (4173); export so it reaches the
+          # test process — an inline prefix on the server line above does NOT propagate here.
+          export PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:4173
           bun x playwright test tests/e2e/setup-wizard.spec.ts --project=wizard
 
       - uses: actions/upload-artifact@v7
@@ -560,6 +563,7 @@ jobs:
           sleep 5
           cat preview.log || true
           bun x wait-on tcp:127.0.0.1:4173 --timeout 180000 --interval 2000
+          export PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:4173
           bun x playwright test --project=auth-setup
 
       - uses: actions/upload-artifact@v7
@@ -648,6 +652,7 @@ jobs:
           PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:4173 \
           node build/index.js > preview.log 2>&1 &
 
+          export PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:4173
           bun x wait-on tcp:127.0.0.1:4173 --timeout 120000 --interval 2000
           bun x playwright test --project=${{ matrix.project }}
 

--- a/src/databases/postgresql/adapter-core.ts
+++ b/src/databases/postgresql/adapter-core.ts
@@ -48,6 +48,12 @@ import postgres from "postgres";
 import { sql as drizzleSql, type SQL } from "drizzle-orm";
 import { pgTable, varchar, jsonb, timestamp, boolean } from "drizzle-orm/pg-core";
 import * as utils from "../core/relational-utils";
+import { RelationalAuthModule } from "../core/relational-auth";
+import { RelationalContentModule } from "../core/relational-content";
+import { RelationalMediaModule } from "../core/relational-media";
+import { RelationalSystemModule } from "../core/relational-system";
+import { BatchModule } from "../core/batch-module";
+import { CollectionModule } from "../core/collection-module";
 
 export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAdapter {
   public type = "postgresql";
@@ -101,7 +107,6 @@ export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAda
   // Domain module getters
   public get auth(): any {
     if (!this._auth) {
-      const { RelationalAuthModule } = require("../core/relational-auth");
       this._auth = new RelationalAuthModule(this as any, this.schema);
     }
     return this._auth;
@@ -109,7 +114,6 @@ export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAda
 
   public get content(): any {
     if (!this._content) {
-      const { RelationalContentModule } = require("../core/relational-content");
       this._content = new RelationalContentModule(this as any, this.schema);
     }
     return this._content;
@@ -117,7 +121,6 @@ export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAda
 
   public get media(): any {
     if (!this._media) {
-      const { RelationalMediaModule } = require("../core/relational-media");
       this._media = new RelationalMediaModule(this as any, this.schema);
     }
     return this._media;
@@ -125,7 +128,6 @@ export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAda
 
   public get system(): any {
     if (!this._system) {
-      const { RelationalSystemModule } = require("../core/relational-system");
       this._system = new RelationalSystemModule(this as any, this.schema);
     }
     return this._system;
@@ -133,7 +135,6 @@ export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAda
 
   public get batch(): any {
     if (!this._batch) {
-      const { BatchModule } = require("../core/batch-module");
       this._batch = new BatchModule(this as any);
     }
     return this._batch;
@@ -141,7 +142,6 @@ export abstract class PostgresAdapterCore extends BaseAdapter implements ISqlAda
 
   public get collection(): any {
     if (!this._collection) {
-      const { CollectionModule } = require("../core/collection-module");
       this._collection = new CollectionModule(this as any);
     }
     return this._collection;

--- a/src/databases/sqlite/adapter-core.ts
+++ b/src/databases/sqlite/adapter-core.ts
@@ -35,6 +35,12 @@ import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
 import * as utils from "../core/relational-utils";
 import { SQLiteQueryBuilder } from "./sq-lite-query-builder";
 import { TransactionModule } from "./transaction-module";
+import { RelationalAuthModule } from "../core/relational-auth";
+import { RelationalContentModule } from "../core/relational-content";
+import { RelationalMediaModule } from "../core/relational-media";
+import { RelationalSystemModule } from "../core/relational-system";
+import { BatchModule } from "../core/batch-module";
+import { CollectionModule } from "../core/collection-module";
 
 // --- Types ---
 export type SQLiteConfig = { connectionString?: string; readonly?: boolean };
@@ -105,7 +111,6 @@ export abstract class SQLiteAdapterCore extends BaseAdapter implements ISqlAdapt
   // Domain module getters
   public get auth(): any {
     if (!this._auth) {
-      const { RelationalAuthModule } = require("../core/relational-auth");
       this._auth = new RelationalAuthModule(this as any, this.schema);
     }
     return this._auth;
@@ -113,7 +118,6 @@ export abstract class SQLiteAdapterCore extends BaseAdapter implements ISqlAdapt
 
   public get content(): any {
     if (!this._content) {
-      const { RelationalContentModule } = require("../core/relational-content");
       this._content = new RelationalContentModule(this as any, this.schema);
     }
     return this._content;
@@ -121,7 +125,6 @@ export abstract class SQLiteAdapterCore extends BaseAdapter implements ISqlAdapt
 
   public get media(): any {
     if (!this._media) {
-      const { RelationalMediaModule } = require("../core/relational-media");
       this._media = new RelationalMediaModule(this as any, this.schema);
     }
     return this._media;
@@ -129,7 +132,6 @@ export abstract class SQLiteAdapterCore extends BaseAdapter implements ISqlAdapt
 
   public get system(): any {
     if (!this._system) {
-      const { RelationalSystemModule } = require("../core/relational-system");
       this._system = new RelationalSystemModule(this as any, this.schema);
     }
     return this._system;
@@ -137,7 +139,6 @@ export abstract class SQLiteAdapterCore extends BaseAdapter implements ISqlAdapt
 
   public get batch(): any {
     if (!this._batch) {
-      const { BatchModule } = require("../core/batch-module");
       this._batch = new BatchModule(this as any);
     }
     return this._batch;
@@ -145,7 +146,6 @@ export abstract class SQLiteAdapterCore extends BaseAdapter implements ISqlAdapt
 
   public get collection(): any {
     if (!this._collection) {
-      const { CollectionModule } = require("../core/collection-module");
       this._collection = new CollectionModule(this as any);
     }
     return this._collection;


### PR DESCRIPTION
## Why

`next` boots broken in the browser, and CI has been red on every push for 12+ commits. Two independent root causes, two commits.

### 1. Boot crash — `Cannot find module '../core/relational-auth'` (`6c8f93d`)
The sqlite and postgresql adapter cores loaded their domain modules (auth/content/media/system/batch/collection) via CommonJS `require()` inside lazy getters. Under Vite SSR that `require()` resolves relative to `db.ts` and throws, crashing the app on first boot. Replaced with static ESM imports (`relational-*` only type-imports the adapter, so no runtime cycle).

> Note: the earlier CSP hydration/icon regressions are **already fixed on `next`** (security hook now scopes strict CSP to `/api/` only; Iconify hosts allowlisted in `vite.config.ts` `kit.csp`). This PR is the boot fix alone.

### 2. CI E2E "passes locally, fails on GitHub" (`726a415`)
`playwright.config.ts` defaults `baseURL` to `http://127.0.0.1:5173` (the Vite dev port). CI serves the **production build on :4173** but set `PLAYWRIGHT_TEST_BASE_URL=…:4173` only as an inline prefix on the server-start line — so it never reached the later `playwright test` process. Tests fell back to :5173 → `ERR_CONNECTION_REFUSED` on every CI run, while passing locally (where `bun run dev` serves :5173). Export the var before the test command in the **wizard**, **auth-setup**, and **app** E2E jobs.

## Verification
- Quality gate green on both commits: `tsc --noEmit` + `svelte-check` = **0 errors**, **334/334 unit tests**.
- Dev server boots clean (Vite ready on :5173); `GET /` and `GET /login` → **200**; no `relational-auth` error in logs.

## Note (out of scope here)
`bun audit` reports CRITICAL CVEs that will still fail the `security-audit` job — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)