### PR TITLE
style(ui): apply blue-light/green-dark accent pair to remaining primary actions

### DIFF
--- a/src/components/system/builder/logic-builder.svelte
+++ b/src/components/system/builder/logic-builder.svelte
@@ -91,7 +91,7 @@
 				<button
 					class="btn btn-sm font-mono font-bold tracking-wider px-4
 						{value.type === 'AND' 
-							? 'preset-filled-primary-500' 
+							? 'preset-filled-tertiary-500 dark:preset-filled-primary-500' 
 							: 'preset-filled-secondary-500'}"
 					onclick={() => toggleGroupType(value!)}
 				>

--- a/src/components/system/builder/widget-fields.svelte
+++ b/src/components/system/builder/widget-fields.svelte
@@ -217,7 +217,7 @@
 
 			<div class="flex gap-2">
 				<!-- Save Button -->
-				<button class="preset-filled-primary-500 btn" aria-label="Save" onclick={handleSave}>Save</button>
+				<button class="preset-filled-tertiary-500 dark:preset-filled-primary-500 btn" aria-label="Save" onclick={handleSave}>Save</button>
 				<!-- Cancel Button -->
 				<button class="preset-outlined-secondary-500 btn-icon mr-2" aria-label="Cancel" onclick={handleCancel}>
 					<iconify-icon icon="material-symbols:close" width="24"></iconify-icon>

--- a/src/routes/(app)/config/collectionbuilder/+page.svelte
+++ b/src/routes/(app)/config/collectionbuilder/+page.svelte
@@ -568,7 +568,7 @@ $effect(() => {
 {#snippet saveButton(isHeader = false)}
 	<button
 		onclick={handleSave}
-		class="btn flex items-center gap-1 {isHeader ? 'btn-sm sm:btn-md preset-filled-primary-500' : 'preset-filled-primary-500'}"
+		class="btn flex items-center gap-1 {isHeader ? 'btn-sm sm:btn-md preset-filled-tertiary-500 dark:preset-filled-primary-500' : 'preset-filled-tertiary-500 dark:preset-filled-primary-500'}"
 		disabled={isLoading || Object.keys(nodesToSave).length === 0}
 		title={Object.keys(nodesToSave).length === 0 ? 'No changes to save' : 'Save changes'}
 		aria-keyshortcuts="mod+s"

--- a/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/+page.svelte
+++ b/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/+page.svelte
@@ -210,7 +210,7 @@ $effect(() => {
 					<StickyActions>
 					<button
 						onclick={() => handleCollectionSave()}
-						class="preset-filled-primary-500 btn flex items-center gap-1 min-w-[100px]"
+						class="preset-filled-tertiary-500 dark:preset-filled-primary-500 btn flex items-center gap-1 min-w-[100px]"
 						disabled={isLoading}
 					>
 						{#if isLoading}

--- a/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/tabs/collection-widget/modal-widget-form.svelte
+++ b/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/tabs/collection-widget/modal-widget-form.svelte
@@ -167,7 +167,7 @@ const cForm = "border border-surface-500 p-4 space-y-4 rounded-xl";
 			<button type="button" aria-label={button_cancel()} class="btn preset-outlined-secondary-500" onclick={() => modalState.close()}>
 				{button_cancel()}
 			</button>
-			<button type="button" aria-label={button_save()} class="btn preset-filled-primary-500" onclick={onFormSubmit}>{button_save()}</button>
+			<button type="button" aria-label={button_save()} class="btn preset-filled-tertiary-500 dark:preset-filled-primary-500" onclick={onFormSubmit}>{button_save()}</button>
 		</div>
 	</footer>
 </div>

--- a/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/tabs/collection-widget/tabs-fields/permission.svelte
+++ b/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/tabs/collection-widget/tabs-fields/permission.svelte
@@ -158,7 +158,7 @@ function toggleRoleWrite(roleId: string) {
 							<button
 								type="button"
 								class="rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors {(permissions.readRoles ?? []).includes(role._id)
-									? 'preset-filled-primary-500'
+									? 'preset-filled-tertiary-500 dark:preset-filled-primary-500'
 									: 'border-surface-200-800 bg-surface-50-950 text-surface-200 hover:border-primary-500/60 hover:bg-surface-100-900'}"
 								onclick={() => toggleRoleRead(role._id)}
 							>
@@ -177,7 +177,7 @@ function toggleRoleWrite(roleId: string) {
 							<button
 								type="button"
 								class="rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors {(permissions.writeRoles ?? []).includes(role._id)
-									? 'preset-filled-primary-500'
+									? 'preset-filled-tertiary-500 dark:preset-filled-primary-500'
 									: 'border-surface-200-800 bg-surface-50-950 text-surface-200 hover:border-primary-500/60 hover:bg-surface-100-900'}"
 								onclick={() => toggleRoleWrite(role._id)}
 							>

--- a/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/tabs/collection-widget/widget-editor.svelte
+++ b/src/routes/(app)/config/collectionbuilder/[action]/[...contentPath]/tabs/collection-widget/widget-editor.svelte
@@ -159,7 +159,7 @@ function handleDelete() {
 				<button type="button" onclick={handleBack} class="preset-outlined-secondary-500 btn">
 					{currentStep === 0 ? button_cancel() : button_previous()}
 				</button>
-				<button type="button" onclick={handleNext} class="preset-filled-primary-500 btn">
+				<button type="button" onclick={handleNext} class="preset-filled-tertiary-500 dark:preset-filled-primary-500 btn">
 					{currentStep === steps.length - 1 ? button_save() : button_next()}
 				</button>
 			</div>

--- a/src/routes/(app)/config/collectionbuilder/nested-content/modal-name-conflict.svelte
+++ b/src/routes/(app)/config/collectionbuilder/nested-content/modal-name-conflict.svelte
@@ -95,7 +95,7 @@ function validateCustomName(name: string): boolean {
 		<button type="button" class="preset-outlined-surface-500 btn" onclick={handleCancel}>Cancel</button>
 		<button
 			type="button"
-			class="preset-filled-primary-500 btn"
+			class="preset-filled-tertiary-500 dark:preset-filled-primary-500 btn"
 			onclick={handleConfirm}
 			disabled={useCustomName ? !validateCustomName(customName) : !selectedName}
 		>

--- a/src/routes/(app)/config/collectionbuilder/nested-content/tree-view-node.svelte
+++ b/src/routes/(app)/config/collectionbuilder/nested-content/tree-view-node.svelte
@@ -255,7 +255,8 @@ function handleKeyDown(e: KeyboardEvent) {
 			<button
 				type="button"
 				class="drag-handle btn-icon preset-tonal-surface-500 rounded cursor-grab active:cursor-grabbing opacity-60 hover:opacity-100 flex items-center justify-center hover:bg-surface-300 dark:hover:bg-surface-600 transition-all duration-200 hover:scale-110"
-				class:preset-filled-primary-500={keyboardReorderMode}
+				class:preset-filled-tertiary-500={keyboardReorderMode}
+				class:dark:preset-filled-primary-500={keyboardReorderMode}
 				onclick={(e) => {
 					e.stopPropagation();
 					if (keyboardReorderMode) {

--- a/src/routes/(app)/config/workflows/workflow-builder.svelte
+++ b/src/routes/(app)/config/workflows/workflow-builder.svelte
@@ -150,7 +150,7 @@ function selectNode(id: string) {
 		<div class="flex gap-2">
 			<button class="btn preset-tonal-surface" onclick={addState}>+ Add State</button>
 			<button class="btn preset-tonal-surface" onclick={addTransition}>+ Add Transition</button>
-			<button class="btn preset-filled-primary-500" onclick={saveWorkflow}>Save Workflow</button>
+			<button class="btn preset-filled-tertiary-500 dark:preset-filled-primary-500" onclick={saveWorkflow}>Save Workflow</button>
 		</div>
 	</div>
 
@@ -202,7 +202,7 @@ function selectNode(id: string) {
 				{const node = states.find(s => s.id === selectedNodeId)}
 				{#if node}
 					<div class="space-y-6" in:fade>
-                        <div class="badge preset-filled-primary-500 text-[10px]">State: {node.id}</div>
+                        <div class="badge preset-filled-tertiary-500 dark:preset-filled-primary-500 text-[10px]">State: {node.id}</div>
 						<div class="space-y-2">
 							<label for="state-name" class="label text-xs font-bold">Display Label</label>
 							<input id="state-name" bind:value={node.label} class="input input-sm" />


### PR DESCRIPTION
## What

Brings the last **12 interactive primary actions** (10 files) into line with the documented *dynamic accent-pair policy* (`style-guide-gui.mdx`): primary actions are **blue in light mode, green in dark mode**.

These spots still used a standalone `preset-filled-primary-500` (green in *both* modes). Each is converted to `preset-filled-tertiary-500 dark:preset-filled-primary-500`, matching the `<Button variant="primary">` primitive and the existing `class:`-directive idiom already used in the image-editor controls.

## Sites changed
- collectionbuilder: save buttons (`+page`, `[...contentPath]/+page`), modal confirm/save (`modal-name-conflict`, `modal-widget-form`), widget-editor next/save, reorder-mode toggle (`tree-view-node`, via dual `class:` directives), permission read/write role chips
- workflows: Save Workflow button + state badge
- system builder: logic-builder AND/OR toggle, widget-fields save

## Intentional exclusions
- `src/app.css` — the `@utility preset-filled-primary-500` definition (must stay)
- `right-sidebar.svelte` — `hover:preset-filled-primary-500-hover` references an **undefined** utility (dead class); fixing it is a separate dead-class cleanup, not an accent-color change

## Verification
- `bun run check` (svelte-check): **3881 files, 0 errors, 0 warnings**
- pre-commit quality gate passed
- `button.test.ts` unaffected (the dual-mode string still contains the asserted substring)

## Notes
This completes the *primary-color* half of the paused #410/#413 work. The broader hardcoded-Tailwind-color→token sweep (#410's other half, ~871 usages now on `next`) is intentionally **not** in this PR and should land separately with an exclusion list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)