### PR TITLE
refactor(collection-builder): simplify first-run UX

### DIFF
--- a/src/routes/(app)/config/collectionbuilder/+page.svelte
+++ b/src/routes/(app)/config/collectionbuilder/+page.svelte
@@ -629,11 +629,13 @@ function modalLoadPreset(): void {
 		</Button>
 
 		<Button
-			href="/config/collectionbuilder/new"
+			type="button"
+			onclick={handleAddCollectionClick}
 			variant="primary"
 			rounded={true}
 			size="lg"
 			class="group w-52 justify-center"
+			disabled={isLoading}
 			data-testid="add-collection-button"
 		>
 			<iconify-icon icon="ic:round-plus" width="24" class="transition-transform group-hover:rotate-90"></iconify-icon>
@@ -654,6 +656,10 @@ function modalLoadPreset(): void {
 			</Button>
 		{/if}
 	</div>
+
+	<p class="mb-4 text-center text-sm text-surface-600 dark:text-surface-300" role="note">
+		Templates apply immediately. Categories and layout changes require <strong>Save</strong>.
+	</p>
 
 	<div class="max-h-[calc(100vh-120px)] overflow-auto p-4" data-testid="collection-builder-board">
 		<div class="mx-auto w-full max-w-screen-2xl">

--- a/src/routes/(app)/config/collectionbuilder/nested-content/empty-state.svelte
+++ b/src/routes/(app)/config/collectionbuilder/nested-content/empty-state.svelte
@@ -2,6 +2,11 @@
 @file src/routes/(app)/config/collectionbuilder/nested-content/empty-state.svelte
 @component
 **Premium Empty State for Collection Builder**
+
+### Features:
+- Quick Start as the recommended first path for new users
+- Manual collection creation and optional category grouping
+- Helper text explaining instant templates vs staged Save workflow
 -->
 
 <script lang="ts">
@@ -13,14 +18,14 @@ import {
 import { fade, scale } from "svelte/transition";
 import { publicEnv } from "@src/stores/global-settings.svelte";
 
-	interface Props {
-		onAddCollection: () => void;
-		onAddCategory: () => void;
-		onLoadPreset?: () => void;
-		onQuickStart?: () => void;
-	}
+interface Props {
+	onAddCollection: () => void;
+	onAddCategory: () => void;
+	onLoadPreset?: () => void;
+	onQuickStart?: () => void;
+}
 
-	let { onAddCollection, onAddCategory, onLoadPreset, onQuickStart }: Props = $props();
+let { onAddCollection, onAddCategory, onLoadPreset, onQuickStart }: Props = $props();
 </script>
 
 <div class="flex flex-col items-center justify-center p-8 py-16 text-center" in:fade={{ duration: 400 }}>
@@ -29,16 +34,13 @@ import { publicEnv } from "@src/stores/global-settings.svelte";
 		class="relative mb-8 flex h-48 w-48 items-center justify-center rounded-full bg-linear-to-br from-primary-500/10 to-tertiary-500/10 dark:from-primary-500/5 dark:to-tertiary-500/5"
 		in:scale={{ duration: 600, delay: 200, start: 0.8 }}
 	>
-		<!-- Background Glow -->
 		<div class="absolute inset-0 animate-pulse rounded-full bg-primary-500/5 blur-3xl"></div>
 
-		<!-- Blueprint/Folder Icon -->
 		<div
 			class="relative flex h-32 w-32 items-center justify-center rounded-3xl border border-white/20 bg-white/40 shadow-2xl backdrop-blur-md dark:bg-surface-800/40"
 		>
 			<iconify-icon icon="fluent-mdl2:build-definition" width="64" class="text-primary-600 dark:text-primary-500"></iconify-icon>
 
-			<!-- Small Floating Plus -->
 			<div
 				class="absolute -right-2 -top-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary-500 text-white shadow-lg shadow-primary-500/40"
 			>
@@ -48,66 +50,82 @@ import { publicEnv } from "@src/stores/global-settings.svelte";
 	</div>
 
 	<!-- Text Content -->
-	<div class="max-w-md space-y-4" in:fade={{ duration: 400, delay: 400 }}>
+	<div class="max-w-lg space-y-4" in:fade={{ duration: 400, delay: 400 }}>
 		<h2 class="text-3xl font-bold tracking-tight text-black dark:text-white sm:text-4xl">
 			Your {publicEnv.SITE_NAME} Blueprint is Empty
 		</h2>
 		<p class="text-lg leading-relaxed text-surface-600 dark:text-surface-50">
-			Create your first collection or category to start structuring your content. A collection defines the fields and rules for your data, while
-			categories help you group them.
+			Start with a Quick Start template for ready-made collections, or add a collection manually. Categories are optional — use them only if you
+			want to group collections in the sidebar.
 		</p>
 	</div>
 
 	<!-- Call to Action -->
-	<div class="mt-10 flex flex-col items-center" in:fade={{ duration: 400, delay: 600 }}>
-		<div class="flex flex-wrap justify-center gap-4">
-			<Button
-				onclick={onAddCategory}
-				variant="tertiary"
-				rounded={true}
-				size="lg"
-				class="group w-52 justify-center"
-				data-testid="add-category-button"
-			>
-				<iconify-icon icon="mdi:folder-plus" width="24" class="transition-transform group-hover:scale-110"></iconify-icon>
-				<span>{collection_addcategory()}</span>
-			</Button>
+	<div class="mt-10 flex w-full max-w-xl flex-col items-center" in:fade={{ duration: 400, delay: 600 }}>
+		<div class="flex w-full flex-col items-center gap-3">
+			{#if onQuickStart}
+				<Button
+					onclick={onQuickStart}
+					variant="primary"
+					rounded={true}
+					size="lg"
+					class="group w-full max-w-sm justify-center sm:w-64"
+					aria-label="Quick Start — recommended for new projects"
+				>
+					<iconify-icon icon="mdi:magic-staff" width="24" class="transition-transform group-hover:rotate-12"></iconify-icon>
+					<span>Quick Start</span>
+				</Button>
+				<p class="text-xs font-medium text-tertiary-600 dark:text-primary-400">Recommended for new projects</p>
+			{/if}
 
 			<Button
 				onclick={onAddCollection}
-				variant="error"
+				variant="primary"
 				rounded={true}
 				size="lg"
-				class="group w-52 justify-center"
+				class="group w-full max-w-sm justify-center sm:w-64"
 				data-testid="add-collection-button"
 			>
 				<iconify-icon icon="ic:round-plus" width="24" class="transition-transform group-hover:rotate-90"></iconify-icon>
 				<span>{collection_add()}</span>
 			</Button>
-
-			{#if onQuickStart}
-				<Button onclick={onQuickStart} variant="secondary" rounded={true} size="lg" class="group w-52 justify-center">
-					<iconify-icon icon="mdi:magic-staff" width="24" class="transition-transform group-hover:rotate-12"></iconify-icon>
-					<span>Quick Start</span>
-				</Button>
-			{/if}
-
-			{#if onLoadPreset}
-				<Button onclick={onLoadPreset} variant="warning" rounded={true} size="lg" class="group w-52 justify-center">
-					<iconify-icon icon="mdi:magic-staff" width="24" class="text-white transition-transform group-hover:rotate-12"></iconify-icon>
-					<span class="text-white">Load Preset</span>
-				</Button>
-			{/if}
 		</div>
 
-		<p class="mt-6 text-sm italic">
+		<div class="mt-8 flex w-full flex-col items-center gap-3 border-t border-surface-200 pt-8 dark:border-surface-700">
+			<p class="text-xs font-semibold uppercase tracking-wide text-surface-500 dark:text-surface-400">Optional</p>
+			<div class="flex flex-wrap justify-center gap-3">
+				<Button
+					onclick={onAddCategory}
+					variant="outline"
+					rounded={true}
+					size="lg"
+					class="group w-52 justify-center"
+					data-testid="add-category-button"
+				>
+					<iconify-icon icon="mdi:folder-plus" width="24" class="transition-transform group-hover:scale-110"></iconify-icon>
+					<span>{collection_addcategory()}</span>
+				</Button>
+
+				{#if onLoadPreset}
+					<Button onclick={onLoadPreset} variant="warning" rounded={true} size="lg" class="group w-52 justify-center">
+						<iconify-icon icon="mdi:package-variant" width="24" class="text-white transition-transform group-hover:scale-110"></iconify-icon>
+						<span class="text-white">Load Preset</span>
+					</Button>
+				{/if}
+			</div>
+		</div>
+
+		<p class="mt-8 max-w-md text-sm text-surface-600 dark:text-surface-300" role="note">
+			Templates apply immediately. Categories and layout changes require <strong>Save</strong>.
+		</p>
+
+		<p class="mt-3 text-sm italic text-surface-500 dark:text-surface-400">
 			At least one collection is required to use the {publicEnv.SITE_NAME} features.
 		</p>
 	</div>
 </div>
 
 <style>
-	/* Subtle animation for the floating state */
 	.relative > div:first-child {
 		animation: float 6s ease-in-out infinite;
 	}


### PR DESCRIPTION
## Summary

Simplifies the first-run Collection Builder experience to make it more intuitive for new users.

### Changes

- Make **Quick Start** the recommended primary action
- Reorder empty-state actions to guide first-time users
- Change **Add Collection** to a secondary action
- Group optional actions separately
- Add helper text explaining which actions require **Save**
- Make toolbar **Add Collection** respect the selected category
- Preserve existing E2E selectors

### Validation

-  bun run lint
-  bun run lint:admin-theme
-  bun run build

### Notes

This PR is limited to Collection Builder UX improvements and does not modify authentication, media, or other admin modules.