### PR TITLE
fix: replace WeakRef session cache with plain LRU Map + fix svelte-inspector config

### DIFF
--- a/src/hooks/handle-authentication.ts
+++ b/src/hooks/handle-authentication.ts
@@ -6,13 +6,13 @@
  * - **Session Management**: Validates session cookies with 3-layer caching (in-memory → Redis → database)
  * - **Security Token Rotation**: Automatic token rotation for active sessions (prevents session hijacking)
  * - **Multi-tenancy**: Hostname-based tenant identification with strict isolation
- * - **Memory Optimization**: WeakRef-based cache with automatic garbage collection
+ * - **Memory Optimization**: LRU cache with TTL-based eviction (no WeakRef GC flakiness)
  * - **Rate Limiting**: Session rotation rate limits to prevent abuse
  * - **Metrics Integration**: Comprehensive tracking via metrics-service *
  *
  * ### Features
  * - Session rotation every 15 minutes for active users (industry best practice)
- * - WeakRef cache with LRU eviction (top 100 hot sessions)
+ * - LRU session cache (top 100 hot sessions) with TTL eviction
  * - Tenant isolation enforcement (prevents cross-tenant access)
  * - Rate-limited refresh attempts (100/min per IP)
  * - Automatic cleanup of expired sessions
@@ -106,13 +106,8 @@ interface SessionCacheEntry {
   user: User;
 }
 
-const sessionCache = new Map<string, WeakRef<SessionCacheEntry>>();
-const sessionCacheRegistry = new FinalizationRegistry<string>((sessionId) => {
-  sessionCache.delete(sessionId);
-});
-
-const MAX_STRONG_REFS = 100;
-const strongRefs = new Map<string, SessionCacheEntry>();
+const MAX_SESSION_CACHE = 100;
+const sessionCache = new Map<string, SessionCacheEntry>();
 const lastRefreshAttempt = new Map<string, number>();
 const lastRotationAttempt = new Map<string, number>();
 
@@ -125,44 +120,29 @@ const SESSION_ROTATION_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes — per indus
 const negativeCache = new BloomFilter(100000, 0.0001); // 2392x speedup for repeat misses
 
 /**
- * Gets a session from the cache, handling WeakRef dereferencing.
+ * Gets a session from the cache (LRU eviction, no WeakRef).
  */
 function getSessionFromCache(sessionId: string): SessionCacheEntry | null {
   const now = Date.now();
-  const strongRef = strongRefs.get(sessionId);
-  if (strongRef && now - strongRef.timestamp < SESSION_CACHE_TTL_MS) {
-    return strongRef;
-  }
-  const weakRef = sessionCache.get(sessionId);
-  if (weakRef) {
-    const entry = weakRef.deref();
-    if (entry && now - entry.timestamp < SESSION_CACHE_TTL_MS) {
-      addToStrongRefs(sessionId, entry);
-      return entry;
-    }
+  const entry = sessionCache.get(sessionId);
+  if (entry && now - entry.timestamp < SESSION_CACHE_TTL_MS) {
+    // Move to end (most recently used)
+    sessionCache.delete(sessionId);
+    sessionCache.set(sessionId, entry);
+    return entry;
   }
   return null;
 }
 
 /**
- * Sets a session in the cache with WeakRef.
+ * Sets a session in the cache with LRU eviction.
  */
 function setSessionInCache(sessionId: string, entry: SessionCacheEntry): void {
-  addToStrongRefs(sessionId, entry);
-  const weakRef = new WeakRef(entry);
-  sessionCache.set(sessionId, weakRef);
-  sessionCacheRegistry.register(entry, sessionId);
-}
-
-/**
- * Adds/updates a session in the strong reference LRU cache.
- */
-function addToStrongRefs(sessionId: string, entry: SessionCacheEntry): void {
-  if (strongRefs.has(sessionId)) strongRefs.delete(sessionId);
-  strongRefs.set(sessionId, entry);
-  if (strongRefs.size > MAX_STRONG_REFS) {
-    const firstKey = strongRefs.keys().next().value;
-    if (firstKey) strongRefs.delete(firstKey);
+  if (sessionCache.has(sessionId)) sessionCache.delete(sessionId);
+  sessionCache.set(sessionId, entry);
+  if (sessionCache.size > MAX_SESSION_CACHE) {
+    const firstKey = sessionCache.keys().next().value;
+    if (firstKey) sessionCache.delete(firstKey);
   }
 }
 
@@ -172,8 +152,8 @@ if (typeof setInterval !== "undefined" && !(globalThis as any)[SESSION_CLEANUP_K
   (globalThis as any)[SESSION_CLEANUP_KEY] = setInterval(
     () => {
       const now = Date.now();
-      for (const [sessionId, data] of strongRefs.entries()) {
-        if (now - data.timestamp > SESSION_CACHE_TTL_MS) strongRefs.delete(sessionId);
+      for (const [sessionId, data] of sessionCache.entries()) {
+        if (now - data.timestamp > SESSION_CACHE_TTL_MS) sessionCache.delete(sessionId);
       }
       for (const [sessionId, timestamp] of lastRefreshAttempt.entries()) {
         if (now - timestamp > 300_000) lastRefreshAttempt.delete(sessionId);
@@ -838,7 +818,6 @@ export const handleAuthentication: Handle = async ({ event, resolve }) => {
 
 export function invalidateSessionCache(sessionId: string, tenantId?: DatabaseId | null): void {
   sessionCache.delete(sessionId);
-  strongRefs.delete(sessionId);
   lastRefreshAttempt.delete(sessionId);
   lastRotationAttempt.delete(sessionId);
 
@@ -878,7 +857,6 @@ export function forceSessionRotation(sessionId: string): void {
 
 export function clearAllSessionCaches(): void {
   sessionCache.clear();
-  strongRefs.clear();
   lastRefreshAttempt.clear();
   lastRotationAttempt.clear();
   negativeCache.clear();
@@ -898,10 +876,9 @@ export function primeSessionMemoryCache(sessionId: string, user: User): void {
 
 export function getSessionCacheStats() {
   return {
-    weakRefs: sessionCache.size,
-    strongRefs: strongRefs.size,
+    cachedSessions: sessionCache.size,
     pendingRefreshes: lastRefreshAttempt.size,
     pendingRotations: lastRotationAttempt.size,
-    maxStrongRefs: MAX_STRONG_REFS,
+    maxCachedSessions: MAX_SESSION_CACHE,
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -905,9 +905,12 @@ export default defineConfig((): any => {
         },
         vitePlugin: {
           inspector: {
-            toggleKeyCombo: "meta-shift",
-            holdMode: false,
-            showToggleButton: "always",
+            // Hold meta+shift+s to inspect elements in the browser and jump to source.
+            // holdMode: true means the inspector is active only while the keys are held,
+            // so it never interferes with e2e tests or normal clicking.
+            toggleKeyCombo: "meta-shift-s",
+            holdMode: true,
+            showToggleButton: "active",
             toggleButtonPos: "bottom-right",
           },
         },


### PR DESCRIPTION
## Summary

Two fixes requested by client:

### 1. Sign-in redirect loop (WeakRef GC bug)

The session cache in `src/hooks/handle-authentication.ts` used `WeakRef<SessionCacheEntry>` to cache user sessions. When the JS GC runs, it collects the `SessionCacheEntry` object, causing `WeakRef.deref()` to return `undefined` → cache miss → falls through to DB lookup → if that transiently fails → `getUserFromSession` returns `null` → auth hook deletes session cookie → redirect to `/login` → user logs in → GC runs again → **loop**.

Already identified in commit `a8c9849d2`: *"Sign-in redirect loop is pre-existing WeakRef GC bug"*

**Fix:** Replaced dual-layer `WeakRef` + `strongRefs` cache with a single plain `Map<string, SessionCacheEntry>` with LRU eviction (max 100 entries) and TTL-based expiry. Same memory bounds, same TTL, but deterministic — no GC-induced cache misses.

`src/hooks/handle-authentication.ts`: −44 lines, +21 lines

### 2. Svelte Inspector not working for debugging

The inspector config in `vite.config.ts` had three issues:

| Setting | Before | After | Why |
|---|---|---|---|
| `toggleKeyCombo` | `"meta-shift"` | `"meta-shift-s"` | Inspector requires a 3-key combo (modifier+modifier+key). `"meta-shift"` alone doesn't register |
| `holdMode` | `false` | `true` | With `false`, inspector toggle stays on and intercepts clicks (breaks e2e). With `true`, hold keys to inspect, release to stop |
| `showToggleButton` | `"always"` | `"active"` | `"always"` shows a floating button at all times, interfering with Playwright. `"active"` only shows while inspector is active |

`vite.config.ts`: +6 lines, −3 lines

### Verification

- ✅ svelte-check: 0 errors, 0 warnings
- ✅ Format (oxfmt): clean
- ✅ User unit tests (133): all pass
- ✅ Auth unit tests (120): all pass
- ✅ Full unit test suite (2164): all pass