### PR TITLE
fix: clear remaining post-hardening unit failures and E2E job-queue crash

### DIFF
--- a/src/services/background/jobs/job-queue-service.ts
+++ b/src/services/background/jobs/job-queue-service.ts
@@ -275,9 +275,15 @@ class JobQueueService {
         );
       }
 
-      // 3. Clean up temp store every 10 cycles
+      // 3. Clean up temp store every ~10 cycles
+      // cleanupTempStore is synchronous — never call .catch on its void return
+      // (that threw TypeError and crashed the process via uncaughtException).
       if (Math.random() > 0.9) {
-        cleanupTempStore().catch((err) => logger.error("[JobQueue] TempStore cleanup error", err));
+        try {
+          cleanupTempStore();
+        } catch (err) {
+          logger.error("[JobQueue] TempStore cleanup error", err);
+        }
       }
     }, intervalMs);
   }

--- a/src/utils/benchmark-sandbox.ts
+++ b/src/utils/benchmark-sandbox.ts
@@ -83,18 +83,19 @@ export function getLocalSandboxMediaRoot(): string {
   return path.resolve(process.cwd(), SANDBOX_MEDIA_REL);
 }
 
-/** 🛡️ Hardened: Canonical path resolution using centralized paths module */
-const CWD = paths.root;
-const LIVE_ROOTS = [
-  paths.privateConfig,
-  paths.collections,
-  paths.compiledCollections,
-  paths.database,
-  paths.media,
-].map((p) => path.normalize(p));
+/** 🛡️ Hardened: live roots re-resolved each call so chdir/tests stay correct */
+function getLiveRoots(): string[] {
+  return [
+    paths.privateConfig,
+    paths.collections,
+    paths.compiledCollections,
+    paths.database,
+    paths.media,
+  ].map((p) => path.normalize(p));
+}
 
 function liveCompiledCollectionsPath(tenantId?: string | null): string {
-  const base = path.join(CWD, ".compiledCollections");
+  const base = path.join(process.cwd(), ".compiledCollections");
   if (tenantId === undefined || tenantId === null) return base;
   return path.join(base, tenantId);
 }
@@ -131,7 +132,7 @@ export function assertLiveDataWriteAllowed(targetPath: string): void {
   }
 
   // 2. Allow test collections
-  const testCollections = path.join(CWD, "config", "collections", "test");
+  const testCollections = path.join(process.cwd(), "config", "collections", "test");
   if (
     normalizedTarget === testCollections ||
     normalizedTarget.startsWith(testCollections + path.sep)
@@ -140,10 +141,10 @@ export function assertLiveDataWriteAllowed(targetPath: string): void {
   }
 
   // 3. Block all other live roots
-  for (const root of LIVE_ROOTS) {
+  for (const root of getLiveRoots()) {
     if (normalizedTarget === root || normalizedTarget.startsWith(root + path.sep)) {
       throw new Error(
-        `[BenchmarkSandbox] SECURITY VIOLATION: Attempted write to live data at '${path.relative(CWD, normalizedTarget)}'. ` +
+        `[BenchmarkSandbox] SECURITY VIOLATION: Attempted write to live data at '${path.relative(process.cwd(), normalizedTarget)}'. ` +
           `Use sandbox paths under ${SANDBOX_COMPILED_ROOT} or ${SANDBOX_MEDIA_REL}.`,
       );
     }

--- a/src/utils/collections-migration.server.ts
+++ b/src/utils/collections-migration.server.ts
@@ -24,12 +24,12 @@ let isMigrating = false;
 /** 🛡️ Hardened: Cross-partition-safe atomic move (copyFile + unlink) */
 async function moveFileAtomically(src: string, dest: string): Promise<boolean> {
   try {
-    await fs
-      .access(dest)
-      .then(() => {
-        throw new Error("Exists");
-      })
-      .catch(() => {});
+    try {
+      await fs.access(dest);
+      return false; // destination already exists — caller should count as skipped
+    } catch {
+      /* dest missing — safe to move */
+    }
     await fs.copyFile(src, dest);
     await fs.unlink(src);
     return true;
@@ -79,16 +79,9 @@ export async function migrateToMultiTenant(tenantId: string): Promise<{
       const src = path.join(flat, entry.name);
       const dest = path.join(tenantDir, entry.name);
 
-      try {
-        await fs.access(dest);
-        result.skipped++;
-        continue;
-      } catch {
-        /* safe to move */
-      }
-
-      await moveFileAtomically(src, dest);
-      result.moved++;
+      const movedOk = await moveFileAtomically(src, dest);
+      if (movedOk) result.moved++;
+      else result.skipped++;
     }
 
     if (result.moved > 0) {
@@ -119,16 +112,9 @@ export async function migrateToSingleTenant(tenantId: string): Promise<{
       const src = path.join(tenantDir, entry.name);
       const dest = path.join(flat, entry.name);
 
-      try {
-        await fs.access(dest);
-        result.skipped++;
-        continue;
-      } catch {
-        /* safe to move */
-      }
-
-      await moveFileAtomically(src, dest);
-      result.moved++;
+      const movedOk = await moveFileAtomically(src, dest);
+      if (movedOk) result.moved++;
+      else result.skipped++;
     }
 
     if (result.moved > 0) {

--- a/src/utils/hook-utils.ts
+++ b/src/utils/hook-utils.ts
@@ -62,7 +62,22 @@ const PUBLIC_EXACT_ROUTES = new Set([
   "/api/auth/saml/login",
 ]);
 
-const PUBLIC_PREFIX_ROUTES = ["/api/settings/public", "/api/theme/public"];
+const PUBLIC_PREFIX_ROUTES = ["/api/settings/public", "/api/theme/public", "/share"];
+
+/**
+ * Public route prefixes/paths for audits and docs.
+ * Prefer isPublicRoute()/isBootstrapRoute() at runtime (O(1) Set + prefix checks).
+ */
+export const PUBLIC_ROUTES: readonly string[] = [
+  ...PUBLIC_EXACT_ROUTES,
+  ...PUBLIC_PREFIX_ROUTES,
+  "/warming-up",
+  "/api/auth",
+  "/api/system",
+  "/register",
+  "/login",
+  "/setup",
+];
 
 // ─── One-shot request classifier ──────────────────────────────────────────
 

--- a/src/utils/path-resolver.ts
+++ b/src/utils/path-resolver.ts
@@ -17,19 +17,30 @@
 import path from "node:path";
 import { sveltyContext, requireTenantId } from "./context";
 
-const CWD = process.cwd();
+/** Always resolve from live process.cwd() so tests/chdir and tooling stay correct. */
+function cwd(): string {
+  return process.cwd();
+}
 
 export const paths = {
-  root: CWD,
+  get root(): string {
+    return cwd();
+  },
 
-  /** Static: config directory root */
-  config: path.join(CWD, "config"),
+  /** Config directory root */
+  get config(): string {
+    return path.join(cwd(), "config");
+  },
 
-  /** Static: flat collection directory (no tenant) */
-  collections: path.join(CWD, "config", "collections"),
+  /** Flat collection directory (no tenant) */
+  get collections(): string {
+    return path.join(cwd(), "config", "collections");
+  },
 
-  /** Static: global media directory */
-  media: path.join(CWD, "mediaFolder", "global"),
+  /** Global media directory */
+  get media(): string {
+    return path.join(cwd(), "mediaFolder", "global");
+  },
 
   /**
    * Dynamic: resolves collection directory based on active tenant.
@@ -38,8 +49,8 @@ export const paths = {
   getCollections: (): string => {
     const tenantId = sveltyContext.getStore()?.tenantId;
     return tenantId
-      ? path.join(CWD, "config", tenantId, "collections")
-      : path.join(CWD, "config", "collections");
+      ? path.join(cwd(), "config", tenantId, "collections")
+      : path.join(cwd(), "config", "collections");
   },
 
   /**
@@ -48,7 +59,7 @@ export const paths = {
    */
   requireCollections: (): string => {
     const tenantId = requireTenantId();
-    return path.join(CWD, "config", tenantId, "collections");
+    return path.join(cwd(), "config", tenantId, "collections");
   },
 
   /**
@@ -58,25 +69,34 @@ export const paths = {
   getMedia: (): string => {
     const tenantId = sveltyContext.getStore()?.tenantId;
     return tenantId
-      ? path.join(CWD, "mediaFolder", tenantId)
-      : path.join(CWD, "mediaFolder", "global");
+      ? path.join(cwd(), "mediaFolder", tenantId)
+      : path.join(cwd(), "mediaFolder", "global");
   },
 
-  /** Static: compiled collections output directory */
-  compiledCollections: path.join(CWD, ".compiledCollections"),
+  /** Compiled collections output directory */
+  get compiledCollections(): string {
+    return path.join(cwd(), ".compiledCollections");
+  },
 
-  /** Static: database directory */
-  database: path.join(CWD, "config", "database"),
+  /** Database directory */
+  get database(): string {
+    return path.join(cwd(), "config", "database");
+  },
 
-  /** Static: private config file */
-  privateConfig: path.join(CWD, "config", "private.ts"),
+  /** Private config file */
+  get privateConfig(): string {
+    return path.join(cwd(), "config", "private.ts");
+  },
 
   /** Benchmark-specific paths (isolated from user live data) */
-  benchmark: {
-    collections: path.join(CWD, "config", "collections", "test"),
-    compiled: path.join(CWD, ".compiledCollections", "test"),
-    sandboxCompiled: path.join(CWD, ".compiledCollections", "test", "_local_sandbox"),
-    sandboxMedia: path.join(CWD, "config", "benchmark-sandbox", "media"),
+  get benchmark() {
+    const root = cwd();
+    return {
+      collections: path.join(root, "config", "collections", "test"),
+      compiled: path.join(root, ".compiledCollections", "test"),
+      sandboxCompiled: path.join(root, ".compiledCollections", "test", "_local_sandbox"),
+      sandboxMedia: path.join(root, "config", "benchmark-sandbox", "media"),
+    };
   },
 
   /**
@@ -87,4 +107,4 @@ export const paths = {
     const relative = path.relative(base, target);
     return !relative.startsWith("..") && !path.isAbsolute(relative);
   },
-} as const;
+};

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -70,7 +70,7 @@ const passwordSchema = pipe(
     `Password must be at least ${getMinPasswordLength()} characters.`,
   ),
   regex(
-    /^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\-=[]{};':"\\|,.<>?]).+$/,
+    /^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>?]).+$/,
     "Password must include a letter, number, and special character.",
   ),
 );

--- a/src/utils/tenant.server.ts
+++ b/src/utils/tenant.server.ts
@@ -14,17 +14,20 @@
 import path from "node:path";
 import { resolveCompiledCollectionsPath } from "./benchmark-sandbox";
 
-const CONFIG_ROOT = path.join(process.cwd(), "config");
+function getConfigRoot(): string {
+  return path.join(process.cwd(), "config");
+}
 
 /**
  * Resolve collection directory. 🛡️ Hardened: Path normalized to prevent escapes.
  */
 export function getCollectionsPath(tenantId?: string | null): string {
-  if (!tenantId) return path.join(CONFIG_ROOT, "collections");
+  const configRoot = getConfigRoot();
+  if (!tenantId) return path.join(configRoot, "collections");
 
   // 🛡️ Sanitize tenantId before joining to prevent path traversal
   const sanitizedTenant = path.basename(tenantId);
-  return path.join(CONFIG_ROOT, sanitizedTenant, "collections");
+  return path.join(configRoot, sanitizedTenant, "collections");
 }
 
 /**
@@ -39,9 +42,9 @@ export function getCompiledCollectionsPath(tenantId?: string | null): string {
  */
 export function extractTenantFromPath(filePath: string): string | null | undefined {
   const normalized = path.normalize(filePath);
-  const relative = path.relative(CONFIG_ROOT, normalized);
+  const relative = path.relative(getConfigRoot(), normalized);
 
-  // If the file is not inside CONFIG_ROOT, it's invalid/external
+  // If the file is not inside config root, it's invalid/external
   if (relative.startsWith("..") || path.isAbsolute(relative)) return undefined;
 
   const parts = relative.split(path.sep);

--- a/tests/e2e/routes/login/signup.spec.ts
+++ b/tests/e2e/routes/login/signup.spec.ts
@@ -116,22 +116,15 @@ test("SignUp First User", async ({ page }) => {
   });
   expect(resetResponse.ok()).toBeTruthy();
 
-  // Go to root — system should redirect to /setup for first-user flow
+  // Go to root — system should redirect to /setup (missing admin) or /login (first-user UI).
+  // Wait for navigation to settle: intermediate hops (/, redirect chains) are not failures.
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await dismissCookieConsent(page);
+  await page.waitForURL(/\/(login|setup)(\/|$|\?)/, { timeout: 15_000 });
 
-  // The system should be in setup mode — either at /setup or showing setup wizard
-  // If redirected to /login, ensureAuth() recreated users after reset.
-  // In that case, just verify the login page loaded (the system is functional).
-  // The signup form flow with a registration token requires setup mode;
-  // setup wizard flows are tested in the wizard project instead.
-  const url = page.url();
-  if (!url.includes("/login")) {
-    // Setup mode — the wizard flow is tested in the wizard project
-    // Just verify we're not stuck at /login
-    await expect(page).not.toHaveURL(/\/login/);
-  }
-  // else: login page rendered — system is functional, signup not tested here
+  // Full signup/wizard coverage lives in the wizard project; this smoke check only
+  // verifies the post-reset entry surface is reachable and not stuck mid-redirect.
+  await expect(page).toHaveURL(/\/(login|setup)/);
 });
 
 test.describe("SignIn & SignOut Flows", () => {

--- a/tests/unit/media/slim-sniffer.test.ts
+++ b/tests/unit/media/slim-sniffer.test.ts
@@ -52,8 +52,25 @@ describe("slim-sniffer — document/video formats", () => {
     });
   });
 
-  it("detects DOCX/ZIP via 50 4B 03 04", () => {
+  it("detects bare ZIP via 50 4B 03 04 when OOXML markers are absent", () => {
     expect(sniffMimeType(Buffer.from([0x50, 0x4b, 0x03, 0x04]))).toEqual({
+      ext: "zip",
+      mime: "application/zip",
+    });
+  });
+
+  it("detects DOCX when ZIP local header carries word/ payload path", () => {
+    // Minimal local-file header + filename "word/document.xml" so the sniffer
+    // can distinguish OOXML from a plain ZIP (filename starts at offset 30).
+    const name = "word/document.xml";
+    const buf = Buffer.alloc(30 + name.length);
+    buf[0] = 0x50;
+    buf[1] = 0x4b;
+    buf[2] = 0x03;
+    buf[3] = 0x04;
+    buf.writeUInt16LE(name.length, 26);
+    buf.write(name, 30, "ascii");
+    expect(sniffMimeType(buf)).toEqual({
       ext: "docx",
       mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     });


### PR DESCRIPTION
## Summary
Clears the remaining unit failures left after utility hardening and fixes a production job-queue crash that killed the E2E webServer mid-suite.

## Changes
### Unit failures (client leftover 8 → 0)
- **`path-resolver` / `tenant.server` / `benchmark-sandbox`**: resolve paths from live `process.cwd()` so tests that `chdir` (structure-persistence, multi-tenant migration) work correctly.
- **`collections-migration`**: fix `moveFileAtomically` exists-check (was always “succeeding” via broken promise chain).
- **`hook-utils`**: restore `PUBLIC_ROUTES` export and treat `/share/*` as public.
- **`schemas`**: fix password special-char regex (broken `[]` class after hardening).
- **`slim-sniffer` tests**: bare ZIP → `zip`; real DOCX content → `docx`.

### E2E process crash
- **`job-queue-service`**: `cleanupTempStore()` is synchronous; calling `.catch` on `void` threw `TypeError: Cannot read properties of undefined (reading 'catch')` and was logged as a fatal uncaughtException, killing Playwright’s preview server.
- **`signup.spec`**: stabilize first-user smoke wait for settled `/login` or `/setup`.

## Validation
- Targeted unit files (previous 8 + related utils): **78/78 pass**
- Integration SQLite (`--db=sqlite --no-build`): **51/51 pass**
- E2E `[firstuser]`: **13/13 pass** (was 1 failed + cascade after server death)
- Full suite load on Windows still shows occasional 15s timeouts in heavy API security files when everything runs together; isolated runs pass (pre-existing flakiness, not introduced here)

## Test plan
- [ ] CI unit suite green
- [ ] CI integration matrix
- [ ] CI e2e-prep (`wizard` → `firstuser` → `auth-setup`) no longer dies on job-queue poll
- [ ] CI chromium shards complete after prep