### PR TITLE
fix: add semantic theme tokens for card contrast and depth in dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -109,6 +109,28 @@
   --color-surface-800: oklch(25% 0 196deg);
   --color-surface-900: oklch(19% 0 196deg);
   --color-surface-950: oklch(16% 0 none);
+
+  /* Semantic Theme Tokens */
+  --color-card: var(--bg-card);
+  --color-bg-card: var(--bg-card);
+
+  --color-surface: var(--bg-surface);
+  --color-bg-surface: var(--bg-surface);
+
+  --color-sidebar: var(--bg-sidebar);
+  --color-bg-sidebar: var(--bg-sidebar);
+
+  --color-theme: var(--border-theme);
+  --color-border-theme: var(--border-theme);
+
+  --color-subtle: var(--border-subtle);
+  --color-border-subtle: var(--border-subtle);
+
+  --color-body: var(--text-body);
+  --color-text-body: var(--text-body);
+
+  --color-muted: var(--text-muted);
+  --color-text-muted: var(--text-muted);
 }
 
 /* ========================================================================
@@ -226,8 +248,7 @@
    ======================================================================== */
 @layer components {
   .card {
-    @apply rounded border border-surface-200 bg-white text-surface-900 shadow-sm;
-    @apply dark:border-surface-700 dark:bg-surface-900 dark:text-surface-50;
+    @apply rounded border border-theme bg-card text-body shadow-md transition-shadow duration-200 hover:shadow-lg;
   }
 
   .badge {
@@ -270,6 +291,27 @@
    🎯 BASE
    ======================================================================== */
 @layer base {
+  :root {
+    --bg-card: #ffffff;
+    --bg-surface: var(--color-surface-100);
+    --bg-sidebar: var(--color-surface-100);
+    --border-theme: var(--color-surface-200);
+    --border-subtle: var(--color-surface-100);
+    --text-body: var(--color-surface-900);
+    --text-muted: var(--color-surface-500);
+  }
+
+  html.dark,
+  .dark {
+    --bg-card: var(--color-surface-800);
+    --bg-surface: var(--color-surface-900);
+    --bg-sidebar: var(--color-surface-950);
+    --border-theme: var(--color-surface-600);
+    --border-subtle: var(--color-surface-700);
+    --text-body: var(--color-surface-100);
+    --text-muted: var(--color-surface-400);
+  }
+
   html {
     @apply bg-secondary-50 text-surface-900;
   }

--- a/src/components/left-sidebar.svelte
+++ b/src/components/left-sidebar.svelte
@@ -312,11 +312,11 @@ Route-driven sidebar content (no dual collapsible section headers):
 					{#if isPinnedOpen}
 						<div class="space-y-0.5" transition:scale={{ duration: 150, start: 0.95 }}>
 							{#each pinnedStore.items as item (item.id)}
-								<div class="group relative flex items-center justify-between rounded hover:bg-surface-100/50 dark:hover:bg-surface-500/20">
+								<div class="group relative flex items-center justify-between rounded hover:bg-surface">
 									<a
 										href={item.path}
 										data-sveltekit-preload-data="hover"
-										class="flex flex-1 items-center gap-2 px-2 py-2 text-sm text-surface-900 dark:text-surface-100 no-underline!"
+										class="flex flex-1 items-center gap-2 px-2 py-2 text-sm text-body no-underline!"
 										onclick={() => {
 											if (isMobile()) toggleUIElement('leftSidebar', 'hidden');
 										}}
@@ -331,7 +331,7 @@ Route-driven sidebar content (no dual collapsible section headers):
 											type="button"
 											onclick={() => pinnedStore.unpin(item.id)}
 											title="Unpin"
-										aria-label="Unpin" class="-xs rounded-full p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-surface-200 dark:hover:bg-surface-800">
+										aria-label="Unpin" class="-xs rounded-full p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-surface">
 											<iconify-icon icon="bi:x" width="16" class="text-surface-500"></iconify-icon>
 										</Button>
 									{/if}
@@ -340,7 +340,7 @@ Route-driven sidebar content (no dual collapsible section headers):
 						</div>
 					{/if}
 				</div>
-				<div class="mx-1 border-0 border-t border-surface-200/50 dark:border-surface-700/50"></div>
+				<div class="mx-1 border-0 border-t border-theme"></div>
 			{/if}
 
 			<!-- 2. Route-context navigation: collections tree OR media folders (never both) -->
@@ -357,7 +357,7 @@ Route-driven sidebar content (no dual collapsible section headers):
 							type="button"
 							onclick={handleBackToCollections}
 							aria-label="Back to Collections"
-							class="flex w-full items-center gap-1.5 rounded py-2 text-xs font-bold uppercase tracking-wider text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-100 {isSidebarFull ? 'justify-start px-2' : 'justify-center'}"
+							class="flex w-full items-center gap-1.5 rounded py-2 text-xs font-bold uppercase tracking-wider text-muted hover:text-body {isSidebarFull ? 'justify-start px-2' : 'justify-center'}"
 						>
 							<iconify-icon icon="bi:arrow-left" width="16" class="shrink-0 text-tertiary-500 dark:text-primary-500"></iconify-icon>
 							{#if isSidebarFull}
@@ -376,7 +376,7 @@ Route-driven sidebar content (no dual collapsible section headers):
 					<Collections />
 				</div>
 
-				<div class="mx-1 border-0 border-t border-surface-200/50 dark:border-surface-700/50"></div>
+				<div class="mx-1 border-0 border-t border-theme"></div>
 
 				<SystemTooltip
 					title="Go to Media Gallery"
@@ -388,7 +388,7 @@ Route-driven sidebar content (no dual collapsible section headers):
 						type="button"
 						onclick={handleGoToMediaGallery}
 						aria-label="Go to Media Gallery"
-						class="flex w-full items-center gap-1.5 rounded py-2 text-xs font-bold uppercase tracking-wider text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-100 {isSidebarFull ? 'justify-start px-2' : 'justify-center'}"
+						class="flex w-full items-center gap-1.5 rounded py-2 text-xs font-bold uppercase tracking-wider text-muted hover:text-body {isSidebarFull ? 'justify-start px-2' : 'justify-center'}"
 					>
 						<iconify-icon icon="bi:image" width="16" class="shrink-0 text-tertiary-500 dark:text-primary-500"></iconify-icon>
 						{#if isSidebarFull}
@@ -404,9 +404,9 @@ Route-driven sidebar content (no dual collapsible section headers):
 	<div class="mt-2 w-full px-1"><Slot name="sidebar" /></div>
 	<!-- Footer -->
 	<div class="mb-2 mt-auto w-full px-1">
-		<div class="mx-1 mb-2 border-0 border-t border-surface-500"></div>
+		<div class="mx-1 mb-2 border-0 border-t border-subtle"></div>
 
-		<div class="grid w-full items-center justify-center gap-1 text-surface-700 dark:text-surface-200 {isSidebarFull ? 'grid-cols-3' : 'grid-cols-2'}">
+		<div class="grid w-full items-center justify-center gap-1 text-body {isSidebarFull ? 'grid-cols-3' : 'grid-cols-2'}">
 			<!-- Avatar -->
 			<div class="{isSidebarFull ? 'order-1 row-span-2' : 'order-1'} flex items-center justify-center">
 				<SystemTooltip title={applayout_userprofile()} positioning={{ placement: 'right' }}>
@@ -417,8 +417,8 @@ Route-driven sidebar content (no dual collapsible section headers):
 						onclick={handleUserClick}
 						aria-label="User Profile"
 						class="{isSidebarFull
-							? 'flex w-full flex-col items-center justify-center rounded p-2 hover:bg-surface-500/20'
-							: 'h-8 w-8 rounded-full hover:bg-surface-500/20'} relative flex items-center justify-center text-center no-underline!"
+							? 'flex w-full flex-col items-center justify-center rounded p-2 hover:bg-surface'
+							: 'h-8 w-8 rounded-full hover:bg-surface'} relative flex items-center justify-center text-center no-underline!"
 						>
 							<Avatar src={avatarUrl} alt="User Avatar" size={isSidebarFull ? 'size-12' : 'size-10'} rounded="rounded-full" class="mx-auto" />
 						{#if isSidebarFull && user?.username}
@@ -438,7 +438,7 @@ Route-driven sidebar content (no dual collapsible section headers):
  				<SystemTooltip title={themeTooltipText} positioning={{ placement: 'right' }}>
  					<!-- Wrapper div needed because ThemeToggle might not forward all events/props or to serve as reliable trigger anchor -->
  					<div class="flex items-center justify-center">
-						<ThemeToggle showTooltip={false} buttonClass="btn-icon hover:bg-surface-300/20" iconSize={28} />
+						<ThemeToggle showTooltip={false} buttonClass="btn-icon hover:bg-surface" iconSize={28} />
  					</div>
  				</SystemTooltip>
  			</div>

--- a/src/routes/(app)/user/+page.svelte
+++ b/src/routes/(app)/user/+page.svelte
@@ -670,8 +670,8 @@
 		});
 	}
 
-	const cardClass = 'border border-surface-200 dark:border-surface-800 p-5 sm:p-6 shadow-sm';
-	const rowClass = 'flex items-center justify-between gap-3 py-3 border-b border-surface-100 dark:border-surface-800 last:border-0';
+	const cardClass = 'border border-theme bg-card text-body p-5 sm:p-6 shadow-sm';
+	const rowClass = 'flex items-center justify-between gap-3 py-3 border-b border-subtle last:border-0';
 	/** Equal width for Security row actions (Setup / Manage / Refresh) */
 	const securityActionBtn = 'min-w-[5.5rem] justify-center shrink-0';
 	/** Row lead icons: tertiary (light) / primary (dark) */
@@ -711,7 +711,7 @@
 										src={normalizeAvatarUrl(user.avatar)}
 										initials={user.username?.slice(0, 2).toUpperCase() || 'AV'}
 										size="size-28"
-										class="size-full rounded-full border-2 border-surface-200 shadow-md pointer-events-none dark:border-surface-600"
+										class="size-full rounded-full border-2 border-theme shadow-md pointer-events-none"
 									/>
 								</button>
 								<!-- Pencil outside circle hit area — positioned shell + SystemTooltip + real button -->
@@ -787,19 +787,19 @@
 
 						<!-- Right: username · email · password (static mask, no reveal) -->
 						<div class="flex min-w-0 flex-col gap-4">
-							<div class="w-full rounded-xl border border-surface-200/90 px-4 py-3 dark:border-surface-700">
-								<p class="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-surface-500">
+							<div class="w-full rounded-xl border border-theme px-4 py-3">
+								<p class="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted">
 									<iconify-icon icon="mdi:account" width={14} class="text-tertiary-500 dark:text-primary-500" aria-hidden="true"
 									></iconify-icon>
 									{username()}
 								</p>
-								<p class="w-full text-base font-medium text-surface-900 dark:text-surface-100" data-testid="profile-username">
+								<p class="w-full text-base font-medium text-body" data-testid="profile-username">
 									{user.username || '—'}
 								</p>
 							</div>
 
-							<div class="w-full rounded-xl border border-surface-200/90 px-4 py-3 dark:border-surface-700">
-								<p class="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-surface-500">
+							<div class="w-full rounded-xl border border-theme px-4 py-3">
+								<p class="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted">
 									<iconify-icon
 										icon="mdi:email-outline"
 										width={14}
@@ -809,7 +809,7 @@
 									{email()}
 								</p>
 								<p
-									class="w-full break-all text-base font-medium text-surface-900 dark:text-surface-100"
+									class="w-full break-all text-base font-medium text-body"
 									data-testid="profile-email"
 								>
 									{user.email || '—'}
@@ -818,18 +818,18 @@
 
 							<!-- Password never shown in plain text — use Change password only -->
 							<div
-								class="w-full rounded-xl border border-surface-200/90 px-4 py-3 dark:border-surface-700"
+								class="w-full rounded-xl border border-theme px-4 py-3"
 								data-testid="profile-password-field"
 							>
-								<p class="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-surface-500">
+								<p class="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted">
 									<iconify-icon icon="mdi:key-variant" width={14} class="text-tertiary-500 dark:text-primary-500" aria-hidden="true"
 									></iconify-icon>
 									Password
 								</p>
-								<p class="font-mono text-base tracking-widest text-surface-500" aria-hidden="true">••••••••••••</p>
-								<p class="mt-1 text-xs text-surface-500">
+								<p class="font-mono text-base tracking-widest text-muted" aria-hidden="true">••••••••••••</p>
+								<p class="mt-1 text-xs text-muted">
 									Passwords are stored hashed and cannot be displayed. Use
-									<strong class="font-medium text-surface-700 dark:text-surface-300">Change password</strong> to set a new one.
+									<strong class="font-medium text-body">Change password</strong> to set a new one.
 								</p>
 							</div>
 
@@ -859,7 +859,7 @@
 							</div>
 
 							{#if isFirstUser}
-								<div class="border-t border-surface-200 pt-4 dark:border-surface-700">
+								<div class="border-t border-subtle pt-4">
 									<Button
 										variant="outline"
 										size="sm"
@@ -879,7 +879,7 @@
 				<!-- ═══ TAB 2: Security — help icons match /setup pattern ═══ -->
 				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="user-security-panel">
 					<AdminCard class={cardClass}>
-						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-surface-500">Sessions &amp; 2FA</h3>
+						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-muted">Sessions &amp; 2FA</h3>
 						<div class="space-y-1">
 							{#if is2FAEnabledGlobal}
 								<div class={rowClass} data-testid="security-2fa-section">
@@ -887,20 +887,20 @@
 										<iconify-icon icon="mdi:two-factor-authentication" class={securityRowIcon} width={20} aria-hidden="true"
 										></iconify-icon>
 										<div class="min-w-0">
-											<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+											<p class="flex items-center gap-1 text-sm font-medium text-body">
 												Two-Factor Authentication
 												<SystemTooltip title={helpTitle('2fa')}>
 													<button
 														type="button"
 														tabindex="-1"
 														aria-label="Help: Two-Factor Authentication"
-														class="ms-0.5 text-surface-400 hover:text-tertiary-500 dark:hover:text-primary-500"
+														class="ms-0.5 text-muted hover:text-tertiary-500 dark:hover:text-primary-500"
 													>
 														<iconify-icon icon="mdi:help-circle-outline" width={16} aria-hidden="true"></iconify-icon>
 													</button>
 												</SystemTooltip>
 											</p>
-											<p class="text-xs {user.is2FAEnabled ? 'text-primary-600 dark:text-primary-500' : 'text-surface-500'}">
+											<p class="text-xs {user.is2FAEnabled ? 'text-primary-600 dark:text-primary-500' : 'text-muted'}">
 												{user.is2FAEnabled ? 'Enabled' : 'Not configured'}
 											</p>
 										</div>
@@ -921,14 +921,14 @@
 								<div class="mb-2 flex flex-wrap items-center justify-between gap-2">
 									<div class="flex min-w-0 items-center gap-2">
 										<iconify-icon icon="mdi:devices" class={securityRowIcon} width={20} aria-hidden="true"></iconify-icon>
-										<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+										<p class="flex items-center gap-1 text-sm font-medium text-body">
 											Active Sessions
 											<SystemTooltip title={helpTitle('sessions')}>
 												<button
 													type="button"
 													tabindex="-1"
 													aria-label="Help: Active Sessions"
-													class="ms-0.5 text-surface-400 hover:text-tertiary-500 dark:hover:text-primary-500"
+													class="ms-0.5 text-muted hover:text-tertiary-500 dark:hover:text-primary-500"
 												>
 													<iconify-icon icon="mdi:help-circle-outline" width={16} aria-hidden="true"></iconify-icon>
 												</button>
@@ -964,7 +964,7 @@
 								{#if sessionsError}
 									<p class="text-xs text-error-500" role="alert">{sessionsError}</p>
 								{:else if sessions.length === 0 && !sessionsLoading}
-									<p class="text-xs text-surface-500">No sessions listed yet. Refresh to load devices.</p>
+									<p class="text-xs text-muted">No sessions listed yet. Refresh to load devices.</p>
 								{:else}
 									<ul
 										class="max-h-[min(70vh,40rem)] space-y-2 overflow-y-auto sm:max-h-[min(75vh,48rem)]"
@@ -974,7 +974,7 @@
 											<li
 												class="rounded-lg border {group.isCurrent
 													? 'border-primary-500/60 bg-primary-500/5 shadow-sm ring-1 ring-primary-500/30 dark:border-primary-500/50 dark:bg-primary-500/10 dark:ring-primary-500/25'
-													: 'border-surface-100 dark:border-surface-800'}"
+													: 'border-subtle'}"
 												data-testid="session-group"
 												data-current={group.isCurrent ? 'true' : 'false'}
 											>
@@ -991,7 +991,7 @@
 															<iconify-icon icon={group.icon} width={18}></iconify-icon>
 														</span>
 														<div class="min-w-0">
-															<p class="font-medium text-surface-800 dark:text-surface-200">
+															<p class="font-medium text-body">
 																{group.title}
 																{#if group.isCurrent}
 																	<Badge
@@ -1004,12 +1004,12 @@
 																	</Badge>
 																{/if}
 																{#if group.sessionCount > 1}
-																	<span class="ms-1 text-[11px] font-normal text-surface-500">
+																	<span class="ms-1 text-[11px] font-normal text-muted">
 																		({group.sessionCount} sessions)
 																	</span>
 																{/if}
 															</p>
-															<p class="mt-0.5 text-[11px] text-surface-500">
+															<p class="mt-0.5 text-[11px] text-muted">
 																{#if group.isCurrent}
 																	<span class="font-medium text-primary-600 dark:text-primary-500"
 																		>You are here · </span
@@ -1055,7 +1055,7 @@
 												<ul
 													class="space-y-1.5 border-t px-3 py-2 {group.isCurrent
 														? 'border-primary-500/25 dark:border-primary-500/30'
-														: 'border-surface-100 dark:border-surface-800'}"
+														: 'border-subtle'}"
 													aria-label="Sessions on this device"
 													data-testid="session-group-members"
 												>
@@ -1063,10 +1063,10 @@
 														<li
 															class="flex items-center justify-between gap-2 rounded-md px-2.5 py-2 text-[11px] {member.isCurrent
 																? 'border border-primary-500/40 bg-primary-500/10 dark:border-primary-500/50 dark:bg-primary-500/15'
-																: 'border border-transparent bg-surface-50/80 dark:bg-surface-900/40'}"
+																: 'border border-transparent bg-surface/80'}"
 															data-testid={member.isCurrent ? 'session-member-current' : 'session-member'}
 														>
-															<span class="min-w-0 text-surface-600 dark:text-surface-300">
+															<span class="min-w-0 text-body">
 																{#if member.isCurrent}
 																	<span
 																		class="inline-flex items-center gap-1 font-bold text-primary-600 dark:text-primary-500"
@@ -1076,15 +1076,15 @@
 																		Current · this tab
 																	</span>
 																{:else}
-																	<span class="font-medium text-surface-800 dark:text-surface-200"
+																	<span class="font-medium text-body"
 																		>Other sign-in</span
 																	>
 																{/if}
 																{#if sessionWhen(member)}
-																	<span class="text-surface-500"> · {sessionWhen(member)}</span>
+																	<span class="text-muted"> · {sessionWhen(member)}</span>
 																{/if}
 																{#if member.ip || member.ipAddress}
-																	<span class="font-mono text-surface-500">
+																	<span class="font-mono text-muted">
 																		· {member.ip || member.ipAddress}</span
 																	>
 																{/if}
@@ -1101,26 +1101,26 @@
 					</AdminCard>
 
 					<AdminCard class={cardClass}>
-						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-surface-500">Login preferences &amp; access</h3>
+						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-muted">Login preferences &amp; access</h3>
 						<div class="space-y-1">
 							<div class={rowClass} data-testid="pref-passkey">
 								<div class="flex min-w-0 items-center gap-3">
 									<iconify-icon icon="mdi:fingerprint" class={securityRowIcon} width={20} aria-hidden="true"></iconify-icon>
 									<div class="min-w-0">
-										<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+										<p class="flex items-center gap-1 text-sm font-medium text-body">
 											Passkeys
 											<SystemTooltip title={helpTitle('passkeys')}>
 												<button
 													type="button"
 													tabindex="-1"
 													aria-label="Help: Passkeys"
-													class="ms-0.5 text-surface-400 hover:text-tertiary-500 dark:hover:text-primary-500"
+													class="ms-0.5 text-muted hover:text-tertiary-500 dark:hover:text-primary-500"
 												>
 													<iconify-icon icon="mdi:help-circle-outline" width={16} aria-hidden="true"></iconify-icon>
 												</button>
 											</SystemTooltip>
 										</p>
-										<p class="text-xs text-surface-500">Prefer passwordless biometric login</p>
+										<p class="text-xs text-muted">Prefer passwordless biometric login</p>
 									</div>
 								</div>
 								<Checkbox
@@ -1136,20 +1136,20 @@
 								<div class="flex min-w-0 items-center gap-3">
 									<iconify-icon icon="mdi:magic-staff" class={securityRowIcon} width={20} aria-hidden="true"></iconify-icon>
 									<div class="min-w-0">
-										<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+										<p class="flex items-center gap-1 text-sm font-medium text-body">
 											Magic Link
 											<SystemTooltip title={helpTitle('magic')}>
 												<button
 													type="button"
 													tabindex="-1"
 													aria-label="Help: Magic Link"
-													class="ms-0.5 text-surface-400 hover:text-tertiary-500 dark:hover:text-primary-500"
+													class="ms-0.5 text-muted hover:text-tertiary-500 dark:hover:text-primary-500"
 												>
 													<iconify-icon icon="mdi:help-circle-outline" width={16} aria-hidden="true"></iconify-icon>
 												</button>
 											</SystemTooltip>
 										</p>
-										<p class="text-xs text-surface-500">Prefer passwordless email login</p>
+										<p class="text-xs text-muted">Prefer passwordless email login</p>
 									</div>
 								</div>
 								<Checkbox
@@ -1166,20 +1166,20 @@
 									<iconify-icon icon="mdi:account-group-outline" class={securityRowIcon} width={20} aria-hidden="true"
 									></iconify-icon>
 									<div class="min-w-0">
-										<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+										<p class="flex items-center gap-1 text-sm font-medium text-body">
 											OAuth Login
 											<SystemTooltip title={helpTitle('oauth')}>
 												<button
 													type="button"
 													tabindex="-1"
 													aria-label="Help: OAuth Login"
-													class="ms-0.5 text-surface-400 hover:text-tertiary-500 dark:hover:text-primary-500"
+													class="ms-0.5 text-muted hover:text-tertiary-500 dark:hover:text-primary-500"
 												>
 													<iconify-icon icon="mdi:help-circle-outline" width={16} aria-hidden="true"></iconify-icon>
 												</button>
 											</SystemTooltip>
 										</p>
-										<p class="text-xs text-surface-500">Sign in with Google, GitHub when configured</p>
+										<p class="text-xs text-muted">Sign in with Google, GitHub when configured</p>
 									</div>
 								</div>
 								<Checkbox
@@ -1195,14 +1195,14 @@
 								<div class="pt-3" data-testid="user-permissions-list">
 									<div class="mb-2 flex items-center gap-2">
 										<iconify-icon icon="mdi:shield-check" class={securityRowIcon} width={20} aria-hidden="true"></iconify-icon>
-										<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+										<p class="flex items-center gap-1 text-sm font-medium text-body">
 											Permissions
 											<SystemTooltip title={helpTitle('permissions')}>
 												<button
 													type="button"
 													tabindex="-1"
 													aria-label="Help: Permissions"
-													class="ms-0.5 text-surface-400 hover:text-tertiary-500 dark:hover:text-primary-500"
+													class="ms-0.5 text-muted hover:text-tertiary-500 dark:hover:text-primary-500"
 												>
 													<iconify-icon icon="mdi:help-circle-outline" width={16} aria-hidden="true"></iconify-icon>
 												</button>
@@ -1242,11 +1242,11 @@
 				<!-- ═══ TAB 3: User Settings — two columns (Appearance/Collab | Privacy) ═══ -->
 				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="user-settings-panel">
 					<AdminCard class={cardClass}>
-						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-surface-500">
+						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-muted">
 							Workspace &amp; collaboration
 						</h3>
 						<div class="space-y-1">
-							<div class="border-b border-surface-100 py-3 dark:border-surface-800" data-testid="workspace-appearance-section">
+							<div class="border-b border-subtle py-3" data-testid="workspace-appearance-section">
 								<div class="mb-2 flex items-center gap-2">
 									<iconify-icon
 										icon="mdi:palette-outline"
@@ -1254,7 +1254,7 @@
 										width={20}
 										aria-hidden="true"
 									></iconify-icon>
-									<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+									<p class="flex items-center gap-1 text-sm font-medium text-body">
 										Workspace Appearance
 										<SystemTooltip title={helpTitle('appearance')}>
 											<button type="button" tabindex="-1" aria-label="Help: Workspace Appearance" class={helpBtnClass}>
@@ -1284,7 +1284,7 @@
 										width={20}
 										aria-hidden="true"
 									></iconify-icon>
-									<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+									<p class="flex items-center gap-1 text-sm font-medium text-body">
 										Collaboration
 										<SystemTooltip title={helpTitle('collaboration')}>
 											<button type="button" tabindex="-1" aria-label="Help: Collaboration" class={helpBtnClass}>
@@ -1295,7 +1295,7 @@
 								</div>
 								<div class="space-y-3 ps-1">
 									<div class="flex items-center justify-between gap-3" data-testid="pref-rtc-enabled">
-										<span class="flex min-w-0 items-center gap-1 text-sm text-surface-700 dark:text-surface-300">
+										<span class="flex min-w-0 items-center gap-1 text-sm text-body">
 											Real-time editing
 											<SystemTooltip title={helpTitle('rtc-enabled')}>
 												<button type="button" tabindex="-1" aria-label="Help: Real-time editing" class={helpBtnClass}>
@@ -1312,7 +1312,7 @@
 										/>
 									</div>
 									<div class="flex items-center justify-between gap-3" data-testid="pref-rtc-sound">
-										<span class="flex min-w-0 items-center gap-1 text-sm text-surface-700 dark:text-surface-300">
+										<span class="flex min-w-0 items-center gap-1 text-sm text-body">
 											Sound notifications
 											<SystemTooltip title={helpTitle('rtc-sound')}>
 												<button
@@ -1339,7 +1339,7 @@
 					</AdminCard>
 
 					<AdminCard class={cardClass}>
-						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-surface-500">
+						<h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-muted">
 							Privacy &amp; extensions
 						</h3>
 						<div class="space-y-1">
@@ -1351,7 +1351,7 @@
 										width={20}
 										aria-hidden="true"
 									></iconify-icon>
-									<p class="flex items-center gap-1 text-sm font-medium text-surface-900 dark:text-surface-100">
+									<p class="flex items-center gap-1 text-sm font-medium text-body">
 										Privacy &amp; Data (GDPR)
 										<SystemTooltip title={helpTitle('privacy')}>
 											<button
@@ -1370,19 +1370,19 @@
 									onclick={modalPrivacyData}
 									data-testid="privacy-data-btn"
 									aria-label="Privacy and Data GDPR — open export and erase options"
-									class="flex w-full items-center gap-3 rounded-lg border border-surface-200 p-3 text-start transition-colors hover:bg-surface-100/50 dark:border-surface-700 dark:hover:bg-surface-800/50"
+									class="flex w-full items-center gap-3 rounded-lg border border-theme p-3 text-start transition-colors hover:bg-surface/50"
 								>
 									<div class="min-w-0 flex-1">
-										<p class="text-sm font-medium text-surface-900 dark:text-surface-100">
+										<p class="text-sm font-medium text-body">
 											View, export, or erase your data
 										</p>
-										<p class="text-xs text-surface-500">
+										<p class="text-xs text-muted">
 											Opens a secure dialog for download and anonymize actions
 										</p>
 									</div>
 									<iconify-icon
 										icon="mdi:chevron-right"
-										class="shrink-0 text-surface-400"
+										class="shrink-0 text-muted"
 										width={18}
 										aria-hidden="true"
 									></iconify-icon>

--- a/src/routes/(app)/user/components/admin-area.svelte
+++ b/src/routes/(app)/user/components/admin-area.svelte
@@ -652,32 +652,32 @@
 	}
 </script>
 
-	<AdminCard
-		data-testid="user-admin-area"
-		class="flex flex-col border border-surface-200 bg-white shadow-sm backdrop-blur-md dark:border-surface-800 dark:bg-surface-900/50"
-	>
-		<!-- Header: Tabs + Invite button -->
-		<div class="flex items-center justify-between gap-3 px-4 pt-3">
-			<div class="flex border-b border-surface-200 dark:border-surface-700 grow" role="tablist" aria-label="User management views">
-				<button
-					type="button"
-					role="tab"
-					aria-selected={showUserList}
-					data-testid="admin-tab-users"
-					onclick={() => showView('users')}
-					class="flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 -mb-px transition-colors {showUserList ? 'border-tertiary-500 dark:border-primary-500 text-tertiary-500 dark:text-primary-500' : 'border-transparent text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'}"
-				>
-					<iconify-icon icon="mdi:account-group" width={18}></iconify-icon>
-					Users
-					<Badge preset="tonal" color="secondary" size="sm" class="ms-1">{systemUserCount}</Badge>
-				</button>
+<AdminCard
+	data-testid="user-admin-area"
+	class="flex flex-col border border-theme bg-card shadow-sm backdrop-blur-md"
+>
+	<!-- Header: Tabs + Invite button -->
+	<div class="flex items-center justify-between gap-3 px-4 pt-3">
+		<div class="flex border-b border-subtle grow" role="tablist" aria-label="User management views">
+			<button
+				type="button"
+				role="tab"
+				aria-selected={showUserList}
+				data-testid="admin-tab-users"
+				onclick={() => showView('users')}
+				class="flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 -mb-px transition-colors {showUserList ? 'border-tertiary-500 dark:border-primary-500 text-tertiary-500 dark:text-primary-500' : 'border-transparent text-muted hover:text-body'}"
+			>
+				<iconify-icon icon="mdi:account-group" width={18}></iconify-icon>
+				Users
+				<Badge preset="tonal" color="secondary" size="sm" class="ms-1">{systemUserCount}</Badge>
+			</button>
 				<button
 					type="button"
 					role="tab"
 					aria-selected={showUsertoken}
 					data-testid="admin-tab-tokens"
 					onclick={() => showView('tokens')}
-					class="flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 -mb-px transition-colors {showUsertoken ? 'border-tertiary-500 dark:border-primary-500 text-tertiary-500 dark:text-primary-500' : 'border-transparent text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'}"
+					class="flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 -mb-px transition-colors {showUsertoken ? 'border-tertiary-500 dark:border-primary-500 text-tertiary-500 dark:text-primary-500' : 'border-transparent text-muted hover:text-body'}"
 				>
 					<iconify-icon icon="material-symbols:key-outline" width={18}></iconify-icon>
 					Invitations

--- a/src/routes/(app)/user/components/modal-edit-avatar.svelte
+++ b/src/routes/(app)/user/components/modal-edit-avatar.svelte
@@ -347,7 +347,7 @@ Efficiently handles avatar uploads with validation, deletion, and real-time prev
 
 	// Base Classes
 
-	const cForm = 'border border-surface-500 p-4 space-y-4 rounded';
+	const cForm = 'border border-theme p-4 space-y-4 rounded';
 </script>
 
 <div class="modal-avatar space-y-4">
@@ -362,7 +362,7 @@ Efficiently handles avatar uploads with validation, deletion, and real-time prev
 							alt="User avatar"
 							initials="AB"
 							size="size-32"
-							class="rounded-full border-4 border-surface-200 dark:border-surface-700 shadow-xl aspect-square"
+							class="rounded-full border-4 border-theme shadow-xl aspect-square"
 						/>
 
 						<!-- Hover/Focus overlay cue when not uploading -->


### PR DESCRIPTION
Fixes flat, low-contrast admin UI reported after native UI component migration. LeftSideBar and /user page cards looked unstyled because app.css had no semantic theme tokens — components hardcoded inconsistent light/dark classes directly, making dark-mode cards nearly invisible against the page background.