### PR TITLE
feat(media-gallery): sidebar drag-and-drop, folder tree store, and image editor crop fixes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -284,3 +284,23 @@
     @apply bg-surface-950 text-surface-100;
   }
 }
+
+/* ========================================================================
+   Media gallery → folder drops (@thisux/sveltednd)
+   ========================================================================
+   sveltednd always paints before/after (blue) drop-position lines via
+   .drop-before / .drop-after — useful for sortable lists, but wrong for
+   "drop into this folder" targets (no insert index). The library has no
+   option to turn those indicators off, so we hide them only on nodes
+   marked data-media-drop-target (sidebar folders, breadcrumbs, and the
+   mobile drag folder rail). Every media drop target must carry that
+   attribute or the blue line comes back. Other sveltednd UIs (entry
+   list, collection builder, etc.) keep the lines.
+   ======================================================================== */
+[data-media-drop-target].drop-before::before,
+[data-media-drop-target].drop-after::after,
+[data-media-drop-target].drop-left::before,
+[data-media-drop-target].drop-right::after {
+  content: none;
+  display: none;
+}

--- a/src/components/image-editor/editor-mobile-toolbar.svelte
+++ b/src/components/image-editor/editor-mobile-toolbar.svelte
@@ -28,7 +28,7 @@ Compact mobile top chrome — three-zone grid layout, pill groups, circular Done
 <header class="shrink-0 p-0 bg-transparent border-b-0" role="toolbar" aria-label="Image editor mobile">
 	<div class="grid grid-cols-[1fr_auto_1fr] gap-2 items-center w-full min-h-[--editor-control-h]">
 		<div class="flex gap-1.5 items-center justify-self-start min-h-[--editor-control-h]">
-			<div class="inline-flex gap-0 items-center h-[--editor-control-h] p-[--editor-pill-pad] rounded-full border border-[--editor-chrome-border] bg-white/9 box-border">
+			<div class="inline-flex gap-0 items-center h-[--editor-control-h] p-[--editor-pill-pad] rounded-full border border-[--editor-chrome-border] bg-white/[0.09] box-border">
 				<button
 					type="button"
 					class="inline-flex items-center justify-center shrink-0 p-0 rounded-full bg-transparent cursor-pointer transition-[background,color,opacity] duration-150 border-none text-[rgba(255,255,255,0.94)] disabled:opacity-[0.22] disabled:cursor-not-allowed hover:text-white hover:bg-white/10 [&_iconify-icon]:block [&_iconify-icon]:leading-[0]"
@@ -52,7 +52,7 @@ Compact mobile top chrome — three-zone grid layout, pill groups, circular Done
 		</div>
 
 		<div class="flex gap-1.5 items-center justify-self-center min-h-[--editor-control-h]">
-			<div class="inline-flex gap-0 items-center h-[--editor-control-h] p-[--editor-pill-pad] rounded-full border border-[--editor-chrome-border] bg-white/9 box-border">
+			<div class="inline-flex gap-0 items-center h-[--editor-control-h] p-[--editor-pill-pad] rounded-full border border-[--editor-chrome-border] bg-white/[0.09] box-border">
 				<button
 					type="button"
 					class="inline-flex items-center justify-center shrink-0 p-0 rounded-full bg-transparent cursor-pointer transition-[background,color,opacity] duration-150 border-none text-[rgba(255,255,255,0.94)] disabled:opacity-[0.22] disabled:cursor-not-allowed hover:text-white hover:bg-white/10 [&_iconify-icon]:block [&_iconify-icon]:leading-[0]"

--- a/src/components/image-editor/editor-toolbar.svelte
+++ b/src/components/image-editor/editor-toolbar.svelte
@@ -71,7 +71,7 @@ Three-zone grid: compare (start), undo/redo + zoom (center), Done (end).
 				aria-pressed={isComparing}
 				aria-label="Toggle compare mode"
 			>
-				<iconify-icon icon="mdi:history" width="18" aria-hidden="true"></iconify-icon>
+				<iconify-icon icon="mdi:compare-horizontal" width="18" aria-hidden="true"></iconify-icon>
 			</button>
 		</div>
 

--- a/src/components/image-editor/widgets/crop/controls.svelte
+++ b/src/components/image-editor/widgets/crop/controls.svelte
@@ -7,25 +7,19 @@ Pintura-style crop bottom dock — pill buttons, horizontal scroll, no card chro
 	import type { CropShape } from './types';
 	import { imageEditorStore } from '@src/stores/image-editor-store.svelte';
 
+	// `crop` and `onCropChange` props are still passed by tool.svelte but only consumed by
+	// the temporarily hidden numeric inputs — uncomment them together with that block.
 	let {
-			crop,
-			onRotateLeft,
-			onRotateRight,
-			onFlipHorizontal,
-			onFlipVertical,
+			// crop,
 			onCropShapeChange,
 			onAspectRatio,
-			onCropChange,
+			// onCropChange,
 			cropShape
 		}: {
-			crop: { x: number; y: number; width: number; height: number };
-			onRotateLeft: () => void;
-			onRotateRight: () => void;
-			onFlipHorizontal: () => void;
-			onFlipVertical?: () => void;
+			crop?: { x: number; y: number; width: number; height: number };
 			onCropShapeChange: (shape: CropShape) => void;
 			onAspectRatio: (ratio: number | null) => void;
-			onCropChange: (nextCrop: { x: number; y: number; width: number; height: number }) => void;
+			onCropChange?: (nextCrop: { x: number; y: number; width: number; height: number }) => void;
 			cropShape: CropShape;
 		} = $props();
 
@@ -85,38 +79,18 @@ Pintura-style crop bottom dock — pill buttons, horizontal scroll, no card chro
 		onAspectRatio(preset.ratio || null);
 	}
 
-	function updateCropField(field: 'x' | 'y' | 'width' | 'height', value: string) {
-		const numeric = Number.parseInt(value, 10);
-		if (!Number.isFinite(numeric)) return;
-		onCropChange({ ...crop, [field]: numeric });
-	}
+	// Numeric crop inputs temporarily hidden — restore alongside the commented markup below
+	// function updateCropField(field: 'x' | 'y' | 'width' | 'height', value: string) {
+	// 	const numeric = Number.parseInt(value, 10);
+	// 	if (!Number.isFinite(numeric)) return;
+	// 	onCropChange({ ...crop, [field]: numeric });
+	// }
 
 	function handleKeyDown(e: KeyboardEvent) {
 		if ((e.target as HTMLElement).tagName === 'INPUT') return;
 		const cmdOrCtrl = e.metaKey || e.ctrlKey;
 
 		switch (e.key) {
-			case 'r':
-			case 'R':
-				if (!cmdOrCtrl) {
-					e.preventDefault();
-					onRotateRight();
-				}
-				break;
-			case 'l':
-			case 'L':
-				if (!cmdOrCtrl) {
-					e.preventDefault();
-					onRotateLeft();
-				}
-				break;
-			case 'f':
-			case 'F':
-				if (!cmdOrCtrl) {
-					e.preventDefault();
-					onFlipHorizontal();
-				}
-				break;
 			case '1':
 				e.preventDefault();
 				handleRatio(1);
@@ -138,7 +112,7 @@ Pintura-style crop bottom dock — pill buttons, horizontal scroll, no card chro
 <svelte:window onkeydown={handleKeyDown} />
 
 <div class="flex flex-col flex-[0_0_auto] gap-1 items-stretch w-full min-w-0 h-auto leading-none" role="toolbar" aria-label="Crop controls">
-	<div class="flex flex-wrap gap-1.5 items-center justify-center w-full min-w-0 min-h-0 leading-none flex-nowrap overflow-x-auto overflow-y-hidden pb-0 [scrollbar-width:thin] [scrollbar-color:rgba(255,255,255,0.2)_transparent] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full">
+	<div class="flex flex-nowrap gap-1.5 items-center justify-center w-full min-w-0 min-h-0 leading-none overflow-x-auto overflow-y-hidden pb-0 [scrollbar-width:thin] [scrollbar-color:rgba(255,255,255,0.2)_transparent] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full">
 		{#each aspectPresets as preset, i (preset.label)}
 			<button
 				type="button"
@@ -153,9 +127,9 @@ Pintura-style crop bottom dock — pill buttons, horizontal scroll, no card chro
 				<span>{preset.label}</span>
 			</button>
 		{/each}
-	</div>
 
-	<div class="flex flex-wrap gap-1.5 items-center justify-center w-full min-w-0 min-h-0 leading-none flex-nowrap overflow-x-auto overflow-y-hidden pb-0 [scrollbar-width:thin] [scrollbar-color:rgba(255,255,255,0.2)_transparent] [&::-webkit-scrollbar]:h-1 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full">
+		<div class="shrink-0 w-px h-5 mx-1 bg-[--editor-chrome-border]" aria-hidden="true"></div>
+
 		{#each shapes as shape (shape.id)}
 			<button
 				type="button"
@@ -170,27 +144,9 @@ Pintura-style crop bottom dock — pill buttons, horizontal scroll, no card chro
 				<span>{shape.label}</span>
 			</button>
 		{/each}
-
-		<button type="button" class="inline-flex flex-[0_0_auto] gap-1.5 items-center h-7 px-2.5 text-[11px] font-medium text-[--editor-chrome-text] whitespace-nowrap cursor-pointer bg-transparent border border-transparent rounded-full transition-[background,color,border-color] duration-150 hover:not-disabled:text-[rgba(255,255,255,0.9)] hover:not-disabled:bg-white/[0.09] hover:not-disabled:border-white/[0.12] disabled:cursor-not-allowed disabled:opacity-35" onclick={onRotateLeft} title="Rotate left (L)" aria-label="Rotate left">
-			<iconify-icon icon="mdi:rotate-left" width="15" aria-hidden="true"></iconify-icon>
-			<span>Left</span>
-		</button>
-		<button type="button" class="inline-flex flex-[0_0_auto] gap-1.5 items-center h-7 px-2.5 text-[11px] font-medium text-[--editor-chrome-text] whitespace-nowrap cursor-pointer bg-transparent border border-transparent rounded-full transition-[background,color,border-color] duration-150 hover:not-disabled:text-[rgba(255,255,255,0.9)] hover:not-disabled:bg-white/[0.09] hover:not-disabled:border-white/[0.12] disabled:cursor-not-allowed disabled:opacity-35" onclick={onRotateRight} title="Rotate right (R)" aria-label="Rotate right">
-			<iconify-icon icon="mdi:rotate-right" width="15" aria-hidden="true"></iconify-icon>
-			<span>Right</span>
-		</button>
-		<button type="button" class="inline-flex flex-[0_0_auto] gap-1.5 items-center h-7 px-2.5 text-[11px] font-medium text-[--editor-chrome-text] whitespace-nowrap cursor-pointer bg-transparent border border-transparent rounded-full transition-[background,color,border-color] duration-150 hover:not-disabled:text-[rgba(255,255,255,0.9)] hover:not-disabled:bg-white/[0.09] hover:not-disabled:border-white/[0.12] disabled:cursor-not-allowed disabled:opacity-35" onclick={onFlipHorizontal} title="Flip horizontal (F)" aria-label="Flip horizontal">
-			<iconify-icon icon="mdi:flip-horizontal" width="15" aria-hidden="true"></iconify-icon>
-			<span>Flip H</span>
-		</button>
-		{#if onFlipVertical}
-			<button type="button" class="inline-flex flex-[0_0_auto] gap-1.5 items-center h-7 px-2.5 text-[11px] font-medium text-[--editor-chrome-text] whitespace-nowrap cursor-pointer bg-transparent border border-transparent rounded-full transition-[background,color,border-color] duration-150 hover:not-disabled:text-[rgba(255,255,255,0.9)] hover:not-disabled:bg-white/[0.09] hover:not-disabled:border-white/[0.12] disabled:cursor-not-allowed disabled:opacity-35" onclick={onFlipVertical} title="Flip vertical" aria-label="Flip vertical">
-				<iconify-icon icon="mdi:flip-vertical" width="15" aria-hidden="true"></iconify-icon>
-				<span>Flip V</span>
-			</button>
-		{/if}
 	</div>
 
+	<!-- Numeric crop inputs temporarily hidden — restore by uncommenting this block
 	<div class="flex flex-wrap gap-2 items-center justify-center w-full">
 		<label class="flex flex-col gap-1 items-center min-w-12" for="crop-x">
 			<span class="text-[10px] font-normal text-[rgba(255,255,255,0.4)] lowercase">x</span>
@@ -209,4 +165,5 @@ Pintura-style crop bottom dock — pill buttons, horizontal scroll, no card chro
 			<input id="crop-h" type="number" value={crop.height} min="1" oninput={(e) => updateCropField('height', (e.currentTarget as HTMLInputElement).value)} class="w-13 h-[1.625rem] px-[0.35rem] text-[11px] text-white text-center bg-white/6 border-none rounded-md outline-none focus:bg-white/[0.1] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-inner-spin-button]:m-0 [-moz-appearance:textfield] [appearance:textfield]" />
 		</label>
 	</div>
+	-->
 </div>

--- a/src/components/image-editor/widgets/crop/tool.svelte
+++ b/src/components/image-editor/widgets/crop/tool.svelte
@@ -64,10 +64,22 @@ handles resize the frame in screen space. Image-space crop syncs on release.
 			onCropShapeChange: (s: CropShape) => {
 				cropShape = s;
 				if (s === 'rectangle') {
-					clampViewport();
-					syncImageCropFromViewport();
+					// Free-form rectangle: release the aspect lock so handles resize freely,
+					// and reshape the frame to the image's proportions so the switch is visible
+					// (otherwise a square frame stays square until the user drags a handle)
+					storeState.currentAspectRatio = null;
+					const img = storeState.imageElement;
+					if (img && img.height > 0 && img.width !== img.height) {
+						resizeViewportToRatio(img.width / img.height, s);
+					} else {
+						clampViewport();
+						syncImageCropFromViewport();
+						refreshToolbar();
+					}
 					return;
 				}
+				// Square/circle must stay 1:1 while dragging handles, not just on selection
+				storeState.currentAspectRatio = 1;
 				resizeViewportToRatio(1, s);
 			},
 			onAspectRatio: (r: number | null) => {
@@ -101,10 +113,6 @@ handles resize the frame in screen space. Image-space crop syncs on release.
 							width: storeState.imageElement?.width ?? 0,
 							height: storeState.imageElement?.height ?? 0
 						},
-						onRotateLeft: () => (storeState.rotation -= 90),
-						onRotateRight: () => (storeState.rotation += 90),
-						onFlipHorizontal: () => (storeState.flipH = !storeState.flipH),
-						onFlipVertical: () => (storeState.flipV = !storeState.flipV),
 						onCropChange: (nextCrop: { x: number; y: number; width: number; height: number }) => {
 							storeState.crop = {
 								x: Math.max(0, Math.round(nextCrop.x)),
@@ -442,15 +450,14 @@ handles resize the frame in screen space. Image-space crop syncs on release.
 
 		const cx = cropViewport.x + cropViewport.width / 2;
 		const cy = cropViewport.y + cropViewport.height / 2;
-		let width = cropViewport.width;
-		let height = cropViewport.height;
 		const targetRatio = ratio > 0 ? ratio : 1;
 
-		if (width / height > targetRatio) {
-			width = height * targetRatio;
-		} else {
-			height = width / targetRatio;
-		}
+		// Preserve the frame's area when reshaping — shrinking one side only would
+		// ratchet the frame smaller on every rectangle/square/circle switch.
+		// clampViewport() below scales it back down if it exceeds the image bounds.
+		const area = cropViewport.width * cropViewport.height;
+		let width = Math.sqrt(area * targetRatio);
+		let height = width / targetRatio;
 
 		width = Math.max(MIN_VIEWPORT, width);
 		height = Math.max(MIN_VIEWPORT, height);

--- a/src/components/media-folders.svelte
+++ b/src/components/media-folders.svelte
@@ -19,25 +19,22 @@
 	import { media_root_title } from '@src/paraglide/messages';
 	import { screen } from '@src/stores/screen-size-store.svelte.ts';
 	import { ui } from '@src/stores/ui-store.svelte.ts';
+	import { mediaFolderTree } from '@src/stores/media-folder-tree.svelte.ts';
 	import { logger } from '@utils/logger';
 	import { toast } from '@src/stores/toast.svelte.ts';
+	import { droppable, dndState, type DragDropState } from '@thisux/sveltednd';
 	import {
-		getMediaDragPayload,
-		hasMediaDrag,
+		MEDIA_DRAG_CONTAINER,
+		MEDIA_DROP_OK,
+		MEDIA_DROP_SAME,
 		moveMediaToFolder,
+		type MediaDragData,
 	} from '@utils/media/media-dnd';
+	import { untrack } from 'svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { goto } from '$app/navigation';
 	import { pinnedStore } from '@src/stores/pinned-store.svelte';
 	import { page } from '$app/state';
-
-	interface RawFolder {
-		_id: string;
-		name: string;
-		order?: number;
-		parentId?: string | null;
-		path: string;
-	}
 
 	interface FolderNode {
 		children?: FolderNode[];
@@ -58,18 +55,25 @@
 		}[];
 	}
 
-	// Mutable state
-	let folders = $state<FolderNode[]>([]);
+	// Mutable UI state (folder data lives in mediaFolderTree)
 	let rootExpanded = $state(true);
 	let folderExpanded = $state(new SvelteSet<string>());
 	let activeFolderId = $state('root');
 	let isEditMode = $state(false);
-	let isLoading = $state(true);
-	let error = $state<string | null>(null);
 	let search = $state('');
-	/** Folder id currently highlighted as a media drop target (`root` for media root) */
-	let mediaDropTargetId = $state<string | null>(null);
 	let isMovingMedia = $state(false);
+
+	const folders = $derived(mediaFolderTree.folders);
+	const isLoading = $derived(mediaFolderTree.isLoading);
+	const error = $derived(mediaFolderTree.error);
+
+	/** True only while a media-gallery card (not a folder-reorder drag) is in flight */
+	const isMediaDragActive = $derived(
+		dndState.isDragging && dndState.sourceContainer === MEDIA_DRAG_CONTAINER
+	);
+	/** The sidebar tree is the only media drop surface on every viewport. On mobile
+	 *  it is the overlay drawer, opened for the drag by useMediaDragSidebar. */
+	const mediaDropEnabled = $derived(isMediaDragActive);
 
 	// Derived UI state
 	let isSidebarFull = $derived(ui.state.leftSidebar === 'full');
@@ -89,45 +93,78 @@
 		return folderExpanded.has(id);
 	}
 
+	// ── Spring-load: hovering a collapsed folder during a media drag opens it ──
+	// Without this you have to expand a branch by hand *before* starting the drag
+	// to reach a nested folder. Same dwell behaviour as the mobile folder rail.
+
+	/** Dwell before a collapsed folder springs open — matches the mobile rail. */
+	const SPRING_OPEN_MS = 500;
+
+	let springTimer: ReturnType<typeof setTimeout> | null = null;
+	let springHoverId: string | null = null;
+	/** Folders opened by spring-load, so a cancelled drag leaves the tree as it was. */
+	let springExpanded = new Set<string>();
+	/** Folder that actually received a drop, so its branch stays open afterwards. */
+	let springDropTarget: string | null = null;
+
+	function clearSpringTimer(): void {
+		if (springTimer) {
+			clearTimeout(springTimer);
+			springTimer = null;
+		}
+		springHoverId = null;
+	}
+
+	function onFolderDragEnter(node: FolderNode): void {
+		if (!mediaDropEnabled || springHoverId === node.id) return;
+		clearSpringTimer();
+		const hasChildren = (node.children?.length ?? 0) > 0;
+		if (!hasChildren || isFolderExpanded(node.id)) return;
+		springHoverId = node.id;
+		springTimer = setTimeout(() => {
+			springExpanded.add(node.id);
+			setFolderExpanded(node.id, true);
+			springTimer = null;
+		}, SPRING_OPEN_MS);
+	}
+
+	function onFolderDragLeave(node: FolderNode): void {
+		if (springHoverId !== node.id) return;
+		clearSpringTimer();
+	}
+
+	// Drop a pending spring timer if the sidebar unmounts mid-drag
+	$effect(() => () => clearSpringTimer());
+
+	// Drag over: collapse anything spring-load opened, except the branch that
+	// received the drop — landing there and finding it closed again is jarring.
+	$effect(() => {
+		if (isMediaDragActive) return;
+		untrack(() => {
+			clearSpringTimer();
+			if (springExpanded.size === 0) return;
+			const keep = springDropTarget
+				? new Set(mediaFolderTree.pathOf(springDropTarget).map((f) => f.id))
+				: new Set<string>();
+			const next = new SvelteSet(folderExpanded);
+			for (const id of springExpanded) {
+				if (!keep.has(id)) next.delete(id);
+			}
+			folderExpanded = next;
+			springExpanded = new Set();
+			springDropTarget = null;
+		});
+	});
+
 	// Sync selection from URL (browser back/forward)
 	$effect(() => {
 		activeFolderId = page.url.searchParams.get('folderId') || 'root';
 	});
 
-	// Fetch folders from API
 	async function loadFolders(): Promise<void> {
-		isLoading = true;
-		error = null;
-		try {
-			// Cache-bust: the API layer caches GET /api/system-* responses for 300s,
-			// so a freshly created/renamed/deleted folder would otherwise not appear
-			// until the cache expired. A unique query param sidesteps the L1 cache.
-			const res = await fetch(`/api/system-virtual-folder?t=${Date.now()}`);
-			if (!res.ok) {
-				throw new Error('Network error');
-			}
-			const { success, data } = await res.json();
-			if (!(success && data)) {
-				throw new Error('Invalid response');
-			}
-
-			folders = data
-				.filter((f: RawFolder) => f.path?.startsWith('/'))
-				.map((f: RawFolder) => ({
-					id: f._id,
-					name: f.name,
-					path: f.path,
-					parentId: f.parentId,
-					icon: 'mdi:folder-outline',
-					nodeType: 'virtual' as const,
-					order: f.order ?? 0,
-				}));
-		} catch (err) {
-			error = 'Failed to load folders';
-			logger.error('[MediaFolders] Load error:', err);
+		await mediaFolderTree.load();
+		if (mediaFolderTree.error) {
 			toast.error('Failed to load folders');
-		} finally {
-			isLoading = false;
 		}
 	}
 
@@ -160,6 +197,7 @@
 			map.set(f.id, {
 				...f,
 				icon: 'mdi:folder-outline',
+				nodeType: 'virtual' as const,
 				children: [],
 				depth: 0,
 				onClick: () => selectFolder(f.id),
@@ -225,7 +263,9 @@
 			setFolderExpanded(resolved, true);
 		}
 		if (isMobile) {
-			ui.toggle('leftSidebar', 'collapsed');
+			// 'hidden' is mobile's closed state — the overlay drawer in +layout.svelte
+			// renders for any value other than 'hidden', so 'collapsed' would leave it up.
+			ui.toggle('leftSidebar', 'hidden');
 		}
 		const path = resolved === 'root' ? '/mediagallery' : `/mediagallery?folderId=${resolved}`;
 		goto(path);
@@ -288,41 +328,19 @@
 
 	// ── Media drag → folder drop (grid assets into virtual folders) ──────────
 
-	function clearMediaDropTarget(): void {
-		mediaDropTargetId = null;
-	}
-
-	function handleMediaDragOver(e: DragEvent, folderId: string): void {
-		if (!hasMediaDrag(e.dataTransfer)) return;
-		e.preventDefault();
-		e.stopPropagation();
-		if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
-		if (mediaDropTargetId !== folderId) {
-			mediaDropTargetId = folderId;
-		}
-	}
-
-	function handleMediaDragLeave(e: DragEvent, folderId: string): void {
-		// Only clear when leaving this row (not when entering a child)
-		const related = e.relatedTarget as Node | null;
-		const current = e.currentTarget as HTMLElement | null;
-		if (current && related && current.contains(related)) return;
-		if (mediaDropTargetId === folderId) {
-			mediaDropTargetId = null;
-		}
-	}
-
-	async function handleMediaDrop(e: DragEvent, folderId: string): Promise<void> {
-		if (!hasMediaDrag(e.dataTransfer)) return;
-		e.preventDefault();
-		e.stopPropagation();
-		clearMediaDropTarget();
-
-		const payload = getMediaDragPayload(e.dataTransfer);
-		if (!payload?.ids.length) {
+	async function handleMediaFolderDrop(
+		state: DragDropState<MediaDragData>,
+		folderId: string,
+	): Promise<void> {
+		const ids = state.draggedItem?.ids ?? [];
+		if (!ids.length) {
 			toast.error('No media to move');
 			return;
 		}
+
+		// Keep this branch open once the drag ends (see the spring-load cleanup effect)
+		springDropTarget = folderId;
+		clearSpringTimer();
 
 		// No-op when dropping into the folder already being viewed
 		const currentId = activeFolderId === 'root' ? null : activeFolderId;
@@ -336,7 +354,7 @@
 		isMovingMedia = true;
 
 		try {
-			const moved = await moveMediaToFolder(payload.ids, targetId, {
+			const moved = await moveMediaToFolder(ids, targetId, {
 				csrfToken: page.data.csrfToken,
 			});
 			const folderLabel =
@@ -355,10 +373,6 @@
 		} finally {
 			isMovingMedia = false;
 		}
-	}
-
-	function isMediaDropHighlight(folderId: string): boolean {
-		return mediaDropTargetId === folderId;
 	}
 
 	// Initial load + refresh on global events
@@ -383,17 +397,24 @@
 	{@const selected = activeFolderId === node.id}
 	{@const expanded = folderExpanded.has(node.id)}
 	{@const indent = depth * 12}
-	{@const dropHighlight = isMediaDropHighlight(node.id)}
+	{@const dropHighlight = isMediaDragActive && dndState.targetContainer === node.id}
+	{@const sameFolder = activeFolderId === node.id}
 
 	<div class="group/folder relative flex flex-col">
 		<div
 			role="listitem"
-			class="flex w-full items-center gap-1 rounded py-0.5 text-start text-[15px] font-medium leading-none transition-colors
-				{dropHighlight ? 'bg-primary-500/20 ring-1 ring-inset ring-primary-500/60' : ''}"
+			class="flex w-full items-center gap-1 rounded py-0.5 text-start text-[15px] font-medium leading-none transition-colors"
 			style="padding-inline-start: {indent}px"
-			ondragover={(e) => handleMediaDragOver(e, node.id)}
-			ondragleave={(e) => handleMediaDragLeave(e, node.id)}
-			ondrop={(e) => handleMediaDrop(e, node.id)}
+			use:droppable={{
+				container: node.id,
+				disabled: !mediaDropEnabled,
+				attributes: { dragOverClass: sameFolder ? MEDIA_DROP_SAME : MEDIA_DROP_OK },
+				callbacks: {
+					onDrop: (state: DragDropState<MediaDragData>) => handleMediaFolderDrop(state, node.id),
+					onDragEnter: () => onFolderDragEnter(node),
+					onDragLeave: () => onFolderDragLeave(node),
+				},
+			}}
 			data-media-drop-target={node.id}
 		>
 			{#if hasChildren}
@@ -428,7 +449,11 @@
 					<iconify-icon
 						icon={dropHighlight ? 'mdi:folder-move-outline' : 'mdi:folder-outline'}
 						width="18"
-						class="shrink-0 {dropHighlight ? 'text-primary-500' : 'text-surface-400'}"
+						class="shrink-0 {dropHighlight
+							? sameFolder
+								? 'text-error-500'
+								: 'text-primary-500'
+							: 'text-surface-400'}"
 						aria-hidden="true"
 					></iconify-icon>
 					<span class="truncate">{node.name}</span>
@@ -514,7 +539,10 @@
 
 	<!-- Folder tree (Media Root + folders) -->
 	<div class="media-folders-list" role="tree" aria-label="Folder tree">
-		{#if isLoading}
+		<!-- Spinner only when there is nothing to show. A refresh (folderCreated, or
+			 the mobile drawer mounting mid-drag) keeps the cached tree on screen
+			 instead of blanking it, so a drag never loses its drop targets. -->
+		{#if isLoading && folders.length === 0}
 			<div class="flex flex-col items-center justify-center gap-3 p-6">
 				<div class="flex gap-2">
 					<div class="h-3 w-3 animate-bounce rounded-full bg-tertiary-500 dark:bg-primary-500"></div>
@@ -537,16 +565,19 @@
 				{@const rootNode = tree[0]}
 				{@const rootHasChildren = (rootNode.children?.length ?? 0) > 0}
 				{@const rootSelected = activeFolderId === 'root'}
-				{@const rootDropHighlight = isMediaDropHighlight('root')}
+				{@const rootDropHighlight = isMediaDragActive && dndState.targetContainer === 'root'}
+				{@const rootSameFolder = activeFolderId === 'root'}
 				<div class="flex flex-col" role="tree" aria-label="Media folder tree">
 					<div class="group/root relative flex flex-col">
 						<div
 							role="listitem"
-							class="rounded transition-colors
-								{rootDropHighlight ? 'bg-primary-500/20 ring-1 ring-inset ring-primary-500/60' : ''}"
-							ondragover={(e) => handleMediaDragOver(e, 'root')}
-							ondragleave={(e) => handleMediaDragLeave(e, 'root')}
-							ondrop={(e) => handleMediaDrop(e, 'root')}
+							class="rounded transition-colors"
+							use:droppable={{
+								container: 'root',
+								disabled: !mediaDropEnabled,
+								attributes: { dragOverClass: rootSameFolder ? MEDIA_DROP_SAME : MEDIA_DROP_OK },
+								callbacks: { onDrop: (state: DragDropState<MediaDragData>) => handleMediaFolderDrop(state, 'root') },
+							}}
 							data-media-drop-target="root"
 						>
 							<Button
@@ -570,7 +601,11 @@
 								<iconify-icon
 									icon={rootDropHighlight ? 'mdi:folder-move-outline' : 'mdi:home-outline'}
 									width="18"
-									class="shrink-0 {rootDropHighlight ? 'text-primary-500' : ''}"
+									class="shrink-0 {rootDropHighlight
+										? rootSameFolder
+											? 'text-error-500'
+											: 'text-primary-500'
+										: ''}"
 									aria-hidden="true"
 								></iconify-icon>
 								<span class="truncate">{rootNode.name}</span>
@@ -591,32 +626,20 @@
 					</div>
 				</div>
 			{:else}
-				<!-- Compact sidebar: wrap TreeView with media drop handlers on a container -->
+				<!-- Compact sidebar: wrap TreeView with a single media drop target (TreeView
+					 renders no per-row folder id, so drops always target the active folder —
+					 which is always "already here", so use the reject/error ring). -->
 				<div
 					role="region"
 					aria-label="Media drop target"
-					class="rounded transition-colors
-						{mediaDropTargetId ? 'bg-primary-500/10 ring-1 ring-inset ring-primary-500/40' : ''}"
-					ondragover={(e) => {
-						if (!hasMediaDrag(e.dataTransfer)) return;
-						e.preventDefault();
-						// Drop on compact tree defaults to the active/hovered folder via data attribute if present
-						const el = (e.target as HTMLElement | null)?.closest?.('[data-folder-id]') as HTMLElement | null;
-						const id = el?.dataset?.folderId ?? activeFolderId;
-						handleMediaDragOver(e, id);
+					class="rounded transition-colors"
+					use:droppable={{
+						container: activeFolderId,
+						disabled: !mediaDropEnabled,
+						attributes: { dragOverClass: MEDIA_DROP_SAME },
+						callbacks: { onDrop: (state: DragDropState<MediaDragData>) => handleMediaFolderDrop(state, activeFolderId) },
 					}}
-					ondragleave={(e) => {
-						const related = e.relatedTarget as Node | null;
-						const current = e.currentTarget as HTMLElement | null;
-						if (current && related && current.contains(related)) return;
-						clearMediaDropTarget();
-					}}
-					ondrop={(e) => {
-						if (!hasMediaDrag(e.dataTransfer)) return;
-						const el = (e.target as HTMLElement | null)?.closest?.('[data-folder-id]') as HTMLElement | null;
-						const id = el?.dataset?.folderId ?? mediaDropTargetId ?? activeFolderId;
-						handleMediaDrop(e, id);
-					}}
+					data-media-drop-target={activeFolderId}
 				>
 					<TreeView
 						nodes={tree}

--- a/src/components/media/media-details-modal.svelte
+++ b/src/components/media/media-details-modal.svelte
@@ -17,11 +17,12 @@
 			import Select from '@components/ui/select.svelte';
 			import Badge from '@components/ui/badge.svelte';
 			import Tabs from '@components/ui/tabs.svelte';
-	  import { fade } from "svelte/transition";
-	  import { formatBytes } from "@utils/utils";
-	  import { toast } from "@src/stores/toast.svelte.ts";
-	  import { mediaUrl } from "@utils/media/media-utils";
-	  import { debounce } from "@utils/debounce";
+  import { fade } from "svelte/transition";
+  import { formatBytes } from "@utils/utils";
+  import { toast } from "@src/stores/toast.svelte.ts";
+  import { mediaUrl } from "@utils/media/media-utils";
+  import { debounce } from "@utils/debounce";
+  import { invalidateAll } from '$app/navigation';
   import { clientJsonHeaders } from "@utils/security/client-csrf";
 
   // Props
@@ -183,27 +184,25 @@
     }
   });
 
-  	// ── Inline editable asset field helpers ─────────────────────────────────────
-  	function startEditName() {
-  		editName = file.metadata?.name || file.filename || '';
-  		isEditingName = true;
-  		nameSaveStatus = 'idle';
-  	}
-  	// saveName replaced by debouncedSaveName — fires automatically on input
+  // ── Inline editable asset field helpers ─────────────────────────────────────
+  // Only the "start editing" setters remain: saving is handled by the debounced
+  // auto-save above (debouncedSaveName/Alt/Caption + *SaveStatus). The old manual
+  // saveName/saveAlt/saveCaption were left behind by a merge — unreferenced, and
+  // still assigning isSavingName/Alt/Caption flags that no longer exist.
+  function startEditName() {
+    editName = file.metadata?.name || file.filename || '';
+    isEditingName = true;
+  }
 
-  	function startEditAlt() {
-  		editAlt = file.metadata?.alt || '';
-  		isEditingAlt = true;
-  		altSaveStatus = 'idle';
-  	}
-  	// saveAlt replaced by debouncedSaveAlt — fires automatically on input
+  function startEditAlt() {
+    editAlt = file.metadata?.alt || '';
+    isEditingAlt = true;
+  }
 
-  	function startEditCaption() {
-  		editCaption = file.metadata?.caption || '';
-  		isEditingCaption = true;
-  		captionSaveStatus = 'idle';
-  	}
-  	// saveCaption replaced by debouncedSaveCaption — fires automatically on input
+  function startEditCaption() {
+    editCaption = file.metadata?.caption || '';
+    isEditingCaption = true;
+  }
 
   // ── Info Tab logic ──────────────────────────────────────────────────────────
   async function handleAddTag(e: KeyboardEvent | MouseEvent) {
@@ -212,6 +211,7 @@
 
     isSavingTags = true;
     try {
+      await invalidateAll();
       const currentTags = file.metadata?.tags || [];
       if (currentTags.includes(newTagInput.trim())) {
         toast.error("Tag already exists");
@@ -229,16 +229,14 @@
         body: JSON.stringify({ metadata: updatedMetadata }),
       });
 
-      if (response.ok) {
-        const body = await response.json();
-        if (body.success) {
-          file = body.data;
-          onUpdate(file);
-          newTagInput = "";
-          toast.success("Tag added successfully");
-        }
+      const body = await response.json();
+      if (response.ok && body.success) {
+        file = { ...file, metadata: updatedMetadata };
+        onUpdate(file);
+        newTagInput = "";
+        toast.success("Tag added successfully");
       } else {
-        toast.error("Failed to add tag");
+        toast.error(body?.message || "Failed to add tag");
       }
     } catch (err) {
       toast.error("An error occurred while adding tag");
@@ -251,6 +249,7 @@
     if (!file?._id) return;
 
     try {
+      await invalidateAll();
       const currentTags = file.metadata?.tags || [];
       const updatedMetadata = {
         ...file.metadata,
@@ -263,15 +262,13 @@
         body: JSON.stringify({ metadata: updatedMetadata }),
       });
 
-      if (response.ok) {
-        const body = await response.json();
-        if (body.success) {
-          file = body.data;
-          onUpdate(file);
-          toast.success("Tag removed");
-        }
+      const body = await response.json();
+      if (response.ok && body.success) {
+        file = { ...file, metadata: updatedMetadata };
+        onUpdate(file);
+        toast.success("Tag removed");
       } else {
-        toast.error("Failed to remove tag");
+        toast.error(body?.message || "Failed to remove tag");
       }
     } catch (err) {
       toast.error("An error occurred while removing tag");

--- a/src/components/media/tag-editor/tag-editor-modal.svelte
+++ b/src/components/media/tag-editor/tag-editor-modal.svelte
@@ -13,7 +13,9 @@ Features:
 	import Button from '@components/ui/button.svelte';
 	import Input from '@components/ui/input.svelte';
 	import Modal from '@components/ui/modal.svelte';
+	import ToastContainer from '@src/components/toast-container.svelte';
 	import { page } from "$app/state";
+	import { invalidateAll } from '$app/navigation';
 	import { toast } from '@src/stores/toast.svelte.ts';
 	import { logger } from '@utils/logger';
 	import type { MediaImage } from '@utils/media/media-models';
@@ -89,6 +91,7 @@ Features:
 			return;
 		}
 		try {
+			await invalidateAll();
 			const response = await fetch(`/api/media/${file._id}`, {
 				method: 'PATCH',
 				headers: {
@@ -104,13 +107,11 @@ Features:
 			});
 			const result = await response.json();
 			if (!(response.ok && result.success)) {
-				throw new Error(result.error);
+				throw new Error(result.message || result.error);
 			}
 
-			if (file) {
-				file = result.data;
-				onUpdate(result.data);
-			}
+			file = { ...file, metadata: { ...file.metadata, aiTags: [...(file.metadata?.aiTags || []), newTagInput.trim()] } };
+			onUpdate(file);
 			newTagInput = '';
 			toast.success('Tag added!');
 		} catch (e: unknown) {
@@ -124,6 +125,7 @@ Features:
 			return;
 		}
 		try {
+			await invalidateAll();
 			const metadata = { ...file.metadata };
 			if (type === 'ai') {
 				metadata.aiTags = metadata.aiTags?.filter((t) => t !== tag) || [];
@@ -141,13 +143,11 @@ Features:
 			});
 			const result = await response.json();
 			if (!(response.ok && result.success)) {
-				throw new Error(result.error);
+				throw new Error(result.message || result.error);
 			}
 
-			if (file) {
-				file = result.data;
-				onUpdate(result.data);
-			}
+			file = { ...file, metadata };
+			onUpdate(file);
 		} catch (e: unknown) {
 			const message = e instanceof Error ? e.message : 'Failed to remove tag';
 			toast.error({ description: message });
@@ -161,6 +161,7 @@ Features:
 		}
 
 		try {
+			await invalidateAll();
 			const metadata = { ...file.metadata };
 			if (type === 'ai') {
 				metadata.aiTags = metadata.aiTags?.map((t) => (t === oldTag ? newTag.trim() : t)) || [];
@@ -178,13 +179,11 @@ Features:
 			});
 			const result = await response.json();
 			if (!(response.ok && result.success)) {
-				throw new Error(result.error);
+				throw new Error(result.message || result.error);
 			}
 
-			if (file) {
-				file = result.data;
-				onUpdate(result.data);
-			}
+			file = { ...file, metadata };
+			onUpdate(file);
 		} catch (e: unknown) {
 			const message = e instanceof Error ? e.message : 'Failed to update tag';
 			toast.error({ description: message });
@@ -199,6 +198,7 @@ Features:
 		}
 		isSaving = true;
 		try {
+			await invalidateAll();
 			const currentTags = new SvelteSet(file.metadata?.tags || []);
 			file.metadata?.aiTags?.forEach((t) => {
 				currentTags.add(t);
@@ -220,13 +220,12 @@ Features:
 			});
 			const result = await response.json();
 			if (!(response.ok && result.success)) {
-				throw new Error(result.error);
+				throw new Error(result.message || result.error);
 			}
 
-			if (file) {
-				file = result.data;
-				onUpdate(result.data);
-			}
+			const mergedTags = Array.from(currentTags);
+			file = { ...file, metadata: { ...file.metadata, tags: mergedTags, aiTags: [] } };
+			onUpdate(file);
 			toast.success('Tags saved!');
 		} catch (e: unknown) {
 			const message = e instanceof Error ? e.message : 'Failed to save tags';
@@ -453,6 +452,7 @@ Features:
 			</div>
 		{/snippet}
 	</Modal>
+	<ToastContainer position="responsive" />
 {/if}
 
 <style>

--- a/src/routes/(app)/mediagallery/+page.server.ts
+++ b/src/routes/(app)/mediagallery/+page.server.ts
@@ -190,7 +190,10 @@ export const load: PageServerLoad = async ({ locals, url }) => {
           const publicUrl = resolveMediaPublicPath(mediaItem);
 
           // Use DB-stored thumbnails directly (already has correct URLs from upload)
-          const thumbnails = (mediaItem.thumbnails ?? {}) as Record<string, { url: string }>;
+          const thumbnails = (mediaItem.thumbnails ?? {}) as Record<
+            string,
+            { url: string; width?: number; height?: number; size?: number }
+          >;
           const thumbnailEntry = thumbnails.thumbnail ?? thumbnails.sm ?? null;
 
           return {
@@ -201,9 +204,14 @@ export const load: PageServerLoad = async ({ locals, url }) => {
             url: publicUrl,
             thumbnail: thumbnailEntry ? { url: thumbnailEntry.url } : { url: publicUrl },
             thumbnails,
-            width: (mediaItem as any).width ?? (mediaItem.metadata as any)?.advancedMetadata?.width,
+            width:
+              (mediaItem as any).width ??
+              (mediaItem.metadata as any)?.width ??
+              (mediaItem.metadata as any)?.advancedMetadata?.width,
             height:
-              (mediaItem as any).height ?? (mediaItem.metadata as any)?.advancedMetadata?.height,
+              (mediaItem as any).height ??
+              (mediaItem.metadata as any)?.height ??
+              (mediaItem.metadata as any)?.advancedMetadata?.height,
           };
         } catch (err) {
           logger.error("Error processing media item", {

--- a/src/routes/(app)/mediagallery/+page.svelte
+++ b/src/routes/(app)/mediagallery/+page.svelte
@@ -5,18 +5,20 @@
 
 ### Features:
 - Global hotkeys via src/utils/hotkeys.ts
-- Desktop: drag media onto sidebar folders or breadcrumb ancestors
-- Mobile: drag/drop onto breadcrumbs (sidebar is too narrow); with a selection,
-  tap a parent breadcrumb to move selected items without HTML5 drag
+- Drag media onto sidebar folders or breadcrumbs (same targets everywhere)
+- Mobile: the sidebar drawer opens itself on drag and closes when the drag
+  ends; tapping a breadcrumb also moves a selection without dragging
 -->
 
 <script lang="ts">
 import { onMount } from "svelte";
+import { slide } from "svelte/transition";
 import { invalidateAll } from "$app/navigation";
 import { page } from "$app/state";
 import type { PageData } from "./$types";
 import MediaGrid from "./media-grid.svelte";
 import MediaTable from "./media-table.svelte";
+import MediaDragPreview from "./media-drag-preview.svelte";
 import AdvancedSearchModal from "./advanced-search-modal.svelte";
 import Portal from "@components/ui/portal.svelte";
 import type { SearchCriteria } from "@utils/media/advanced-search";
@@ -35,11 +37,15 @@ import {
 	type StoredMediaBase,
 	MediaTypeEnum,
 } from "@utils/media/media-models";
+import { droppable, dndState, type DragDropState } from "@thisux/sveltednd";
 import {
-	getMediaDragPayload,
-	hasMediaDrag,
+	MEDIA_DRAG_CONTAINER,
+	MEDIA_DROP_OK,
+	MEDIA_DROP_SAME,
 	moveMediaToFolder,
+	type MediaDragData,
 } from "@utils/media/media-dnd";
+import { useMediaDragSidebar } from "@utils/media/media-drag-sidebar.svelte.ts";
 import { modalState } from "@utils/modal.svelte";
 import { showConfirm } from "@utils/modal.svelte";
 import { registerHotkey } from "@src/utils/hotkeys";
@@ -72,9 +78,17 @@ let gridSize = $state<"tiny" | "small" | "medium" | "large">("small");
 	// svelte-ignore state_referenced_locally — data is from $props(), initial seed only
 	let jsonPathFilter = $state((data as { jsonPathFilter?: string }).jsonPathFilter ?? "");
 	let sortBy = $state("newest");
-	/** Breadcrumb folder key currently highlighted as media drop target (`root` | folderId) */
-	let breadcrumbDropKey = $state<string | null>(null);
+	let mobileFiltersExpanded = $state(false);
+	/** True only while a media-gallery card (not some unrelated drag) is in flight */
+	const isMediaDragActive = $derived(
+		dndState.isDragging && dndState.sourceContainer === MEDIA_DRAG_CONTAINER
+	);
+	/** Breadcrumbs accept drops on every viewport — mobile drags the same way */
+	const breadcrumbDropEnabled = $derived(isMediaDragActive);
 	let isMovingMedia = $state(false);
+
+	// Mobile: surface the sidebar folder tree for the duration of the drag.
+	useMediaDragSidebar(() => isMediaDragActive);
 
 const sortOptions = [
 	{ value: "newest", label: "Newest first" },
@@ -146,12 +160,7 @@ const filteredFiles = $derived.by(() => {
 				const hasExif = !!meta?.exif;
 				if (hasExif !== searchCriteria.hasEXIF) return false;
 			}
-			// JSON path filter: `metadata.camera = Canon` · multi AND via `;`
-			if (jsonPathFilter.trim() && !matchesJsonPathFilter(file, jsonPathFilter)) {
-				return false;
-			}
-
-						if (searchCriteria.aspectRatio) {
+			if (searchCriteria.aspectRatio) {
 				if (!img.width || !img.height) return false;
 				const ratio = img.width / img.height;
 				if (searchCriteria.aspectRatio === 'landscape' && ratio <= 1) return false;
@@ -159,6 +168,13 @@ const filteredFiles = $derived.by(() => {
 				if (searchCriteria.aspectRatio === 'square' && ratio !== 1) return false;
 			}
 		}
+
+		// JSON path filter: `metadata.camera = Canon` · multi AND via `;`
+		// Applied independently of advanced search so ?jsonPath= / live input always work.
+		if (jsonPathFilter.trim() && !matchesJsonPathFilter(file, jsonPathFilter)) {
+			return false;
+		}
+
 		return true;
 	});
 
@@ -247,47 +263,24 @@ async function moveIdsToFolder(
 		logger.error("[MediaGallery] Breadcrumb move failed", err);
 	} finally {
 		isMovingMedia = false;
-		breadcrumbDropKey = null;
 	}
 }
 
-function handleBreadcrumbDragOver(e: DragEvent, folderId: string | null): void {
-	if (!hasMediaDrag(e.dataTransfer)) return;
-	// Current folder is not a useful drop target
-	if (isCurrentCrumb(folderId)) return;
-	e.preventDefault();
-	e.stopPropagation();
-	if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
-	const key = crumbDropKey(folderId);
-	if (breadcrumbDropKey !== key) breadcrumbDropKey = key;
-}
-
-function handleBreadcrumbDragLeave(e: DragEvent, folderId: string | null): void {
-	const related = e.relatedTarget as Node | null;
-	const current = e.currentTarget as HTMLElement | null;
-	if (current && related && current.contains(related)) return;
-	if (breadcrumbDropKey === crumbDropKey(folderId)) {
-		breadcrumbDropKey = null;
-	}
-}
-
-async function handleBreadcrumbDrop(e: DragEvent, folderId: string | null, label: string): Promise<void> {
-	if (!hasMediaDrag(e.dataTransfer)) return;
-	e.preventDefault();
-	e.stopPropagation();
-	breadcrumbDropKey = null;
-
+async function handleBreadcrumbDrop(
+	state: DragDropState<MediaDragData>,
+	folderId: string | null,
+	label: string,
+): Promise<void> {
 	if (isCurrentCrumb(folderId)) {
 		toast.info("Already in this folder");
 		return;
 	}
-
-	const payload = getMediaDragPayload(e.dataTransfer);
-	if (!payload?.ids.length) {
+	const ids = state.draggedItem?.ids ?? [];
+	if (!ids.length) {
 		toast.error("No media to move");
 		return;
 	}
-	await moveIdsToFolder(payload.ids, folderId, label);
+	await moveIdsToFolder(ids, folderId, label);
 }
 
 /**
@@ -622,7 +615,7 @@ async function handleOpenFileDetails(file: any) {
 }
 
 function handleUpdateImage(updatedFile: MediaImage) {
-  if (!updatedFile?._id) return;
+	if (!updatedFile?._id) return;
 	const index = files.findIndex((f) => f._id === updatedFile._id);
 	if (index !== -1) {
 		files[index] = updatedFile;
@@ -686,7 +679,7 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 				<span class="hidden sm:inline">{isUploading ? `Uploading…` : "Upload"}</span>
 			</Button>
 
-			<input aria-label="Search media"
+			<input aria-label="Upload media files"
 				type="file"
 				multiple
 				class="hidden"
@@ -769,91 +762,278 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 			</div>
 		{/if}
 
+		<!--
+			Breadcrumbs — always rendered, including at Media Root where the trail is a
+			single crumb, so the path strip never collapses to empty space.
+
+			Every crumb is a drop target on every viewport, mirroring the sidebar tree:
+			an ancestor takes the media (primary ring), the current folder rejects it
+			(error ring) rather than being inert, so the gesture always gets feedback.
+		-->
+		<div class="shrink-0 px-2 sm:px-3" data-testid="media-gallery-breadcrumbs">
+			<nav
+				class="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-surface-200 py-1.5 text-base text-surface-500 sm:gap-2.5 sm:py-2.5 dark:border-surface-800 dark:text-surface-400"
+				aria-label="Folder path — drop media on a parent to move (same as sidebar folders)"
+			>
+				{#each breadcrumbs as crumb, i (crumb.folderId ?? 'root')}
+					{@const isLast = i === breadcrumbs.length - 1}
+					{@const dropKey = crumbDropKey(crumb.folderId)}
+					{@const sameFolder = isCurrentCrumb(crumb.folderId)}
+					{@const isDropTarget = breadcrumbDropEnabled && dndState.targetContainer === dropKey}
+					{@const dropOptions = {
+						container: dropKey,
+						disabled: !breadcrumbDropEnabled,
+						attributes: { dragOverClass: sameFolder ? MEDIA_DROP_SAME : MEDIA_DROP_OK },
+						callbacks: { onDrop: (state: DragDropState<MediaDragData>) => handleBreadcrumbDrop(state, crumb.folderId, crumb.name) },
+					}}
+
+					{#if i > 0}
+						<iconify-icon
+							icon="mdi:chevron-right"
+							width="16"
+							class="shrink-0 text-surface-400 dark:text-surface-500"
+							aria-hidden="true"
+						></iconify-icon>
+					{/if}
+
+					{#if isLast}
+						<!-- Current folder: not a link, but still a droppable so the drag is
+							 told "already here" with the same error ring the sidebar uses. -->
+						<span
+							class="inline-flex max-w-48 shrink-0 items-center gap-1 truncate rounded-md px-2 py-2 font-medium text-surface-800 sm:max-w-[16rem] sm:px-1.5 sm:py-1 dark:text-surface-100"
+							aria-current="page"
+							data-media-drop-target={dropKey}
+							data-testid={`media-breadcrumb-${dropKey}`}
+							title={sameFolder && breadcrumbDropEnabled ? 'Already in this folder' : crumb.name}
+							use:droppable={dropOptions}
+						>
+							{#if isDropTarget}
+								<iconify-icon
+									icon="mdi:folder-remove-outline"
+									width="16"
+									class="shrink-0 text-error-500"
+									aria-hidden="true"
+								></iconify-icon>
+							{/if}
+							<span class="truncate">{crumb.name}</span>
+						</span>
+					{:else}
+						<a
+							href={crumb.folderId ? `/mediagallery?folderId=${crumb.folderId}` : '/mediagallery'}
+							class="inline-flex max-w-48 shrink-0 items-center gap-1 truncate rounded-md px-2 py-2 text-sm font-medium transition-colors sm:max-w-[16rem] sm:px-1.5 sm:py-1 sm:text-base
+								{selectedFiles.size > 0
+									? 'bg-surface-100 text-surface-800 hover:bg-primary-500/15 hover:text-primary-600 dark:bg-surface-800 dark:text-surface-100 dark:hover:text-primary-400'
+									: 'hover:text-primary-500'}"
+							data-preload="hover"
+							data-media-drop-target={dropKey}
+							data-testid={`media-breadcrumb-${dropKey}`}
+							aria-label={selectedFiles.size > 0
+								? `Move ${selectedFiles.size} selected to ${crumb.name}`
+								: `Open folder ${crumb.name}`}
+							title={selectedFiles.size > 0
+								? `Move selection to ${crumb.name}`
+								: `Drop media here (or open) — same as sidebar`}
+							use:droppable={dropOptions}
+							onclick={(e) => handleBreadcrumbActivate(e, crumb.folderId, crumb.name, isLast)}
+						>
+							{#if isDropTarget || selectedFiles.size > 0}
+								<iconify-icon
+									icon={isDropTarget ? 'mdi:folder-move-outline' : 'mdi:folder-outline'}
+									width="16"
+									class="shrink-0 {isDropTarget ? 'text-primary-500' : 'opacity-70'}"
+									aria-hidden="true"
+								></iconify-icon>
+							{/if}
+							<span class="truncate">{crumb.name}</span>
+						</a>
+					{/if}
+				{/each}
+			</nav>
+
+			{#if selectedFiles.size > 0}
+				<p
+					class="pb-2 text-[11px] leading-tight text-surface-500 dark:text-surface-400"
+					role="status"
+				>
+					<span class="sm:hidden">
+						Tap a parent above, or drag an item onto a folder
+					</span>
+					<span class="hidden sm:inline">
+						Drop {selectedFiles.size}
+						{selectedFiles.size === 1 ? 'item' : 'items'} on a sidebar folder or breadcrumb parent to move
+					</span>
+				</p>
+			{/if}
+		</div>
+
 		<!-- Toolbar -->
 		<div class="shrink-0 px-2 sm:px-3" data-testid="media-gallery-toolbar">
-			<div
-				class="flex flex-col gap-2.5 py-3 sm:flex-row sm:items-center sm:gap-3"
-			>
-			<div class="relative min-w-0 w-full sm:flex-1">
-				<iconify-icon icon="mdi:magnify" class="pointer-events-none absolute inset-s-3 top-1/2 z-10 -translate-y-1/2 opacity-50" width="18"></iconify-icon>
-				<Input
-					id="media-gallery-search"
-					bind:value={globalSearchValue}
-					type="search"
-					placeholder="Search media... (Mod+F)"
-					class="w-full ps-9 dark:border-surface-700/60 focus-visible:ring-1"
-					aria-label="Search media assets"
-				/>
+
+			<!-- Mobile toolbar: search + expand button, then collapsible filters -->
+			<div class="flex flex-col gap-1.5 py-2 sm:hidden">
+				<div class="flex items-center gap-2">
+					<div class="relative min-w-0 flex-1">
+						<iconify-icon icon="mdi:magnify" class="pointer-events-none absolute inset-s-3 top-1/2 z-10 -translate-y-1/2 opacity-50" width="18"></iconify-icon>
+						<Input
+							id="media-gallery-search"
+							bind:value={globalSearchValue}
+							type="search"
+							placeholder="Search media... (Mod+F)"
+							class="w-full ps-9 pe-10 dark:border-surface-700/60 focus-visible:ring-1"
+							aria-label="Search media assets"
+						/>
+						<span class="absolute inset-e-2 top-1/2 z-10 -translate-y-1/2">
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								onclick={() => (showAdvancedSearch = true)}
+								aria-label="Advanced search and filters"
+								class="h-7! w-7! min-w-0! px-0! {searchCriteria ? 'text-primary-500' : ''}"
+							>
+								<iconify-icon icon="mdi:filter-variant" width="16"></iconify-icon>
+							</Button>
+						</span>
+					</div>
+					<Button
+						type="button"
+						variant="outline"
+						size="md"
+						onclick={() => (mobileFiltersExpanded = !mobileFiltersExpanded)}
+						aria-label={mobileFiltersExpanded ? 'Hide filters' : 'Show filters'}
+						aria-expanded={mobileFiltersExpanded}
+						class="h-10 w-10 shrink-0 px-0!"
+					>
+						<iconify-icon
+							icon="mdi:chevron-down"
+							width="18"
+							class="transition-transform duration-200 {mobileFiltersExpanded ? 'rotate-180' : ''}"
+						></iconify-icon>
+					</Button>
+				</div>
+
+				{#if mobileFiltersExpanded}
+					<div transition:slide={{ duration: 200 }} class="flex flex-col gap-1.5 pb-1">
+						<div class="flex gap-2">
+							{#if view === 'grid'}
+								<label for="media-type-filter-m" class="sr-only">Filter by media type</label>
+								<Select id="media-type-filter-m" bind:value={selectedMediaType} options={mediaTypeOptions} placeholder="Type" class="flex-1" />
+							{/if}
+							<label for="sort-by-filter-m" class="sr-only">Sort by</label>
+							<Select id="sort-by-filter-m" bind:value={sortBy} options={sortOptions} placeholder="Sort" class="flex-1" />
+						</div>
+						<div class="relative min-w-0 w-full">
+							<Input
+								bind:value={jsonPathFilter}
+								type="text"
+								placeholder='JSON path… e.g. metadata.camera = Canon'
+								class="w-full ps-2 text-xs"
+								aria-label="Filter by JSON path (supports = != ~ > < ; AND)"
+								title="Format: path = value · multi: a = 1; b > 2 · ops: = != ~ > < >= <="
+							/>
+						</div>
+						<div class="flex items-center gap-2">
+							<div class="flex overflow-hidden rounded border border-surface-300 dark:border-surface-600" role="group" aria-label="View mode">
+								<Button type="button" variant={view === 'grid' ? 'primary' : 'ghost'} size="md" onclick={() => (view = 'grid')} aria-label="Grid view" aria-pressed={view === 'grid'} class="h-10! w-10! px-0!">
+									<iconify-icon icon="mdi:grid-large" width="16"></iconify-icon>
+								</Button>
+								<Button type="button" variant={view === 'table' ? 'primary' : 'ghost'} size="md" onclick={() => (view = 'table')} aria-label="Table view" aria-pressed={view === 'table'} class="h-10! w-10! px-0! border-l border-surface-300 dark:border-surface-600">
+									<iconify-icon icon="mdi:format-list-bulleted" width="16"></iconify-icon>
+								</Button>
+							</div>
+							{#if view === 'grid'}
+								<div class="flex overflow-hidden rounded border border-surface-300 dark:border-surface-600" role="group" aria-label="Grid size">
+									{#each (['tiny', 'small', 'medium', 'large'] as const) as size, i}
+										<Button
+											type="button"
+											variant={gridSize === size ? 'primary' : 'ghost'}
+											size="md"
+											onclick={() => (gridSize = size)}
+											aria-label="{size} grid"
+											aria-pressed={gridSize === size}
+											class="h-10! w-8! px-0! text-xs! {i > 0 ? 'border-l border-surface-300 dark:border-surface-600' : ''}"
+										>
+											{size === 'tiny' ? 'XS' : size === 'small' ? 'S' : size === 'medium' ? 'M' : 'L'}
+										</Button>
+									{/each}
+								</div>
+								<Button
+									type="button"
+									variant={isSelectionMode ? 'primary' : 'outline'}
+									size="md"
+									onclick={() => (isSelectionMode = !isSelectionMode)}
+									aria-label="Toggle selection mode"
+									aria-pressed={isSelectionMode}
+									class="h-10 px-3"
+								>
+									{isSelectionMode ? 'Done' : 'Select'}
+								</Button>
+							{/if}
+						</div>
+					</div>
+				{/if}
 			</div>
 
-			<div class="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:shrink-0">
-				{#if view === 'grid'}
-					<label for="media-type-filter" class="sr-only">Filter by media type</label>
-					<Select
-						id="media-type-filter"
-						bind:value={selectedMediaType}
-						options={mediaTypeOptions}
-						placeholder="Type"
-						class="w-full sm:w-28"
+			<!-- Desktop toolbar: single row -->
+			<div class="hidden items-center gap-2 py-2 sm:flex">
+				<div class="relative min-w-0 flex-1">
+					<iconify-icon icon="mdi:magnify" class="pointer-events-none absolute inset-s-3 top-1/2 z-10 -translate-y-1/2 opacity-50" width="18"></iconify-icon>
+					<Input
+						id="media-gallery-search-desktop"
+						bind:value={globalSearchValue}
+						type="search"
+						placeholder="Search media... (Mod+F)"
+						class="w-full ps-9 pe-10 dark:border-surface-700/60 focus-visible:ring-1"
+						aria-label="Search media assets"
 					/>
+					<span class="absolute inset-e-2 top-1/2 z-10 -translate-y-1/2">
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onclick={() => (showAdvancedSearch = true)}
+							aria-label="Advanced Search"
+							data-testid="media-advanced-search"
+							class="h-7! w-7! min-w-0! px-0! {searchCriteria ? 'text-primary-500' : ''}"
+						>
+							<iconify-icon icon="mdi:filter-variant" width="16"></iconify-icon>
+						</Button>
+					</span>
+				</div>
 
-					<label for="media-grid-size" class="sr-only">Grid size</label>
-					<Select
-						id="media-grid-size"
-						bind:value={gridSize}
-						options={[
-							{ value: 'tiny', label: 'Tiny' },
-							{ value: 'small', label: 'Small' },
-							{ value: 'medium', label: 'Medium' },
-							{ value: 'large', label: 'Large' },
-						]}
-						placeholder="Size"
-						class="w-full sm:w-28"
-					/>
+				{#if view === 'grid'}
+					<div class="w-28 shrink-0">
+						<label for="media-type-filter" class="sr-only">Filter by media type</label>
+						<Select id="media-type-filter" bind:value={selectedMediaType} options={mediaTypeOptions} placeholder="Type" />
+					</div>
 				{/if}
 
-				<label for="sort-by-filter" class="sr-only">Sort by</label>
-				<Select
-					id="sort-by-filter"
-					bind:value={sortBy}
-					options={sortOptions}
-					placeholder="Sort"
-					class="w-full sm:w-36"
-				/>
+				<div class="w-36 shrink-0">
+					<label for="sort-by-filter" class="sr-only">Sort by</label>
+					<Select id="sort-by-filter" bind:value={sortBy} options={sortOptions} placeholder="Sort" />
+				</div>
 
-					<div class="relative min-w-0 w-full sm:w-auto sm:min-w-40">
-						<Input
-							bind:value={jsonPathFilter}
-							type="text"
-							placeholder='JSON path… e.g. metadata.camera = Canon; metadata.iso > 100'
-							class="w-full ps-2 text-xs"
-							aria-label="Filter by JSON path (supports = != ~ > < ; AND)"
-							title="Format: path = value · multi: a = 1; b > 2 · ops: = != ~ > < >= <="
-						/>
-					</div>
-
-					<Button
-					variant={searchCriteria ? 'tertiary' : 'ghost'}
-					size="sm"
-					onclick={() => showAdvancedSearch = true}
-					aria-label="Advanced Search"
-					data-testid="media-advanced-search"
-					class="h-10 text-sm {searchCriteria ? 'preset-filled-tertiary-500 text-white' : ''}"
-				>
-					<iconify-icon icon="mdi:filter-variant" width="18"></iconify-icon>
-					<span class="hidden sm:inline">{searchCriteria ? 'Filtered' : 'Filter'}</span>
-				</Button>
+				<div class="relative min-w-0 w-44 shrink-0">
+					<Input
+						bind:value={jsonPathFilter}
+						type="text"
+						placeholder='JSON path… e.g. metadata.camera = Canon'
+						class="w-full ps-2 text-xs"
+						aria-label="Filter by JSON path (supports = != ~ > < ; AND)"
+						title="Format: path = value · multi: a = 1; b > 2 · ops: = != ~ > < >= <="
+					/>
+				</div>
 
 				<!--
 					Native <button> toggles (not Button component): guarantees aria-label,
 					aria-pressed, data-testid and onclick stay on the DOM node for E2E/a11y.
 				-->
-				<div class="flex h-10 items-center gap-0.5" role="group" aria-label="View mode">
+				<div class="flex shrink-0 overflow-hidden rounded border border-surface-300 dark:border-surface-600" role="group" aria-label="View mode">
 					<button
 						type="button"
 						onclick={() => (view = 'grid')}
-						class="btn relative inline-flex h-10 w-10 min-w-0 items-center justify-center p-0! text-sm font-bold tracking-tight transition-all duration-200 hover:bg-surface-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-500 dark:hover:bg-surface-800/50 dark:focus-visible:ring-surface-300 {view === 'grid'
-							? 'border-b-2 border-primary-500 text-surface-800 dark:text-surface-100'
+						class="relative inline-flex h-10 w-10 min-w-0 items-center justify-center p-0 text-sm font-bold tracking-tight transition-all duration-200 hover:bg-surface-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-500 dark:hover:bg-surface-800/50 dark:focus-visible:ring-surface-300 {view === 'grid'
+							? 'bg-primary-500 text-white'
 							: 'text-surface-500 dark:text-surface-400'}"
 						aria-label="Grid view"
 						aria-pressed={view === 'grid' ? 'true' : 'false'}
@@ -864,8 +1044,8 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 					<button
 						type="button"
 						onclick={() => (view = 'table')}
-						class="btn relative inline-flex h-10 w-10 min-w-0 items-center justify-center p-0! text-sm font-bold tracking-tight transition-all duration-200 hover:bg-surface-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-500 dark:hover:bg-surface-800/50 dark:focus-visible:ring-surface-300 {view === 'table'
-							? 'border-b-2 border-primary-500 text-surface-800 dark:text-surface-100'
+						class="relative inline-flex h-10 w-10 min-w-0 items-center justify-center border-l border-surface-300 p-0 text-sm font-bold tracking-tight transition-all duration-200 hover:bg-surface-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-500 dark:border-surface-600 dark:hover:bg-surface-800/50 dark:focus-visible:ring-surface-300 {view === 'table'
+							? 'bg-primary-500 text-white'
 							: 'text-surface-500 dark:text-surface-400'}"
 						aria-label="Table view"
 						aria-pressed={view === 'table' ? 'true' : 'false'}
@@ -876,118 +1056,38 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 				</div>
 
 				{#if view === 'grid'}
+					<div class="flex shrink-0 overflow-hidden rounded border border-surface-300 dark:border-surface-600" role="group" aria-label="Grid size">
+						{#each (['tiny', 'small', 'medium', 'large'] as const) as size, i}
+							<Button
+								type="button"
+								variant={gridSize === size ? 'primary' : 'ghost'}
+								size="md"
+								onclick={() => (gridSize = size)}
+								aria-label="{size} grid"
+								aria-pressed={gridSize === size}
+								class="h-10! w-8! px-0! text-xs! {i > 0 ? 'border-l border-surface-300 dark:border-surface-600' : ''}"
+							>
+								{size === 'tiny' ? 'XS' : size === 'small' ? 'S' : size === 'medium' ? 'M' : 'L'}
+							</Button>
+						{/each}
+					</div>
+
 					<Button
-						variant={isSelectionMode ? 'surface' : 'ghost'}
-						color={isSelectionMode ? 'var(--color-primary-500)' : undefined}
+						type="button"
+						variant={isSelectionMode ? 'primary' : 'outline'}
+						size="md"
 						onclick={() => (isSelectionMode = !isSelectionMode)}
 						aria-label="Toggle selection mode"
 						aria-pressed={isSelectionMode}
 						data-testid="media-selection-toggle"
-						class="h-10 text-sm"
+						class="h-10 shrink-0 text-sm"
 					>
-						<span class="sm:hidden">{isSelectionMode ? 'Done' : 'Select'}</span>
-						<span class="hidden sm:inline">{isSelectionMode ? 'Exit Selection' : 'Select'}</span>
+						{isSelectionMode ? 'Exit Selection' : 'Select'}
 					</Button>
 				{/if}
 			</div>
-			</div>
+
 		</div>
-
-		<!--
-			Breadcrumbs are first-class drop targets (same move API as the sidebar tree).
-			Desktop: drop groups on a sidebar folder OR any ancestor crumb — identical result.
-			Mobile: sidebar is tight, so crumbs are the main drop/tap path for parents.
-		-->
-		{#if breadcrumbs.length > 1}
-			<div class="shrink-0 px-2 sm:px-3" data-testid="media-gallery-breadcrumbs">
-				<nav
-					class="flex min-w-0 items-center gap-1 overflow-x-auto border-b border-surface-200 py-1.5 text-base text-surface-500 sm:gap-2.5 sm:py-2.5 dark:border-surface-800 dark:text-surface-400"
-					aria-label="Folder path — drop media on a parent to move (same as sidebar folders)"
-				>
-					{#each breadcrumbs as crumb, i (crumb.folderId ?? 'root')}
-						{@const isLast = i === breadcrumbs.length - 1}
-						{@const dropKey = crumbDropKey(crumb.folderId)}
-						{@const isDropTarget = !isLast && breadcrumbDropKey === dropKey}
-						{@const canReceiveMove = !isLast}
-
-						{#if i > 0}
-							<iconify-icon
-								icon="mdi:chevron-right"
-								width="16"
-								class="shrink-0 text-surface-400 dark:text-surface-500"
-								aria-hidden="true"
-							></iconify-icon>
-						{/if}
-
-						{#if isLast}
-							<span
-								class="max-w-48 shrink-0 truncate rounded-md px-2 py-2 font-medium text-surface-800 sm:max-w-[16rem] sm:px-1 sm:py-0 dark:text-surface-100"
-								aria-current="page"
-							>{crumb.name}</span>
-						{:else}
-							<a
-								href={crumb.folderId ? `/mediagallery?folderId=${crumb.folderId}` : '/mediagallery'}
-								class="inline-flex max-w-48 shrink-0 items-center gap-1 truncate rounded-md px-2 py-2 text-sm font-medium transition-colors sm:max-w-[16rem] sm:px-1.5 sm:py-1 sm:text-base
-									{isDropTarget
-										? 'bg-primary-500/20 text-primary-600 ring-1 ring-inset ring-primary-500/70 dark:text-primary-500'
-										: selectedFiles.size > 0
-											? 'bg-surface-100 text-surface-800 hover:bg-primary-500/15 hover:text-primary-600 dark:bg-surface-800 dark:text-surface-100 dark:hover:text-primary-400'
-											: 'hover:text-primary-500'}"
-								data-preload="hover"
-								data-media-drop-target={dropKey}
-								data-testid={`media-breadcrumb-${dropKey}`}
-								aria-label={selectedFiles.size > 0
-									? `Move ${selectedFiles.size} selected to ${crumb.name}`
-									: `Open folder ${crumb.name}`}
-								title={selectedFiles.size > 0
-									? `Move selection to ${crumb.name}`
-									: canReceiveMove
-										? `Drop media here (or open) — same as sidebar`
-										: crumb.name}
-								ondragover={(e) => handleBreadcrumbDragOver(e, crumb.folderId)}
-								ondragleave={(e) => handleBreadcrumbDragLeave(e, crumb.folderId)}
-								ondrop={(e) => handleBreadcrumbDrop(e, crumb.folderId, crumb.name)}
-								onclick={(e) => handleBreadcrumbActivate(e, crumb.folderId, crumb.name, isLast)}
-							>
-								{#if isDropTarget || selectedFiles.size > 0}
-									<iconify-icon
-										icon={isDropTarget ? 'mdi:folder-move-outline' : 'mdi:folder-outline'}
-										width="16"
-										class="shrink-0 {isDropTarget ? 'text-primary-500' : 'opacity-70'}"
-										aria-hidden="true"
-									></iconify-icon>
-								{/if}
-								<span class="truncate">{crumb.name}</span>
-							</a>
-						{/if}
-					{/each}
-				</nav>
-
-				{#if selectedFiles.size > 0}
-					<p
-						class="pb-2 text-[11px] leading-tight text-surface-500 dark:text-surface-400"
-						role="status"
-					>
-						<span class="sm:hidden">
-							Tap a parent folder above, or drop onto it, to move {selectedFiles.size}
-							{selectedFiles.size === 1 ? 'item' : 'items'}
-						</span>
-						<span class="hidden sm:inline">
-							Drop {selectedFiles.size}
-							{selectedFiles.size === 1 ? 'item' : 'items'} on a sidebar folder or breadcrumb parent to move
-						</span>
-					</p>
-				{/if}
-			</div>
-		{:else if selectedFiles.size > 0}
-			<!-- At media root: only sidebar folders are valid destinations for a group move -->
-			<div class="shrink-0 px-2 sm:px-3" data-testid="media-gallery-move-hint">
-				<p class="border-b border-surface-200 py-2 text-[11px] leading-tight text-surface-500 dark:border-surface-800 dark:text-surface-400" role="status">
-					Drop {selectedFiles.size}
-					{selectedFiles.size === 1 ? 'item' : 'items'} on a folder in the sidebar to move
-				</p>
-			</div>
-		{/if}
 
 		<!-- Content — data-view is the canonical E2E signal for grid/table mode -->
 		<div
@@ -1023,6 +1123,8 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 	</div>
 
 	<Slot name="media_gallery" />
+
+	<MediaDragPreview />
 
 	{#if showAdvancedSearch}
 		<Portal>

--- a/src/routes/(app)/mediagallery/media-drag-preview.svelte
+++ b/src/routes/(app)/mediagallery/media-drag-preview.svelte
@@ -1,0 +1,276 @@
+<!--
+@file src/routes/(app)/mediagallery/media-drag-preview.svelte
+@component
+**Custom cursor-anchored drag preview for the media gallery**
+
+Tracks `pointermove` as well as `dragover`, so it follows a finger on touch
+just as it follows the cursor on desktop. Rendered `pointer-events-none` at
+`z-[9999]` so it paints above the mobile sidebar drawer without ever
+intercepting `elementFromPoint` hit-testing.
+
+`@thisux/sveltednd` has no cursor-following ghost of its own on the native
+HTML5 path — the browser draws its default drag image (a screenshot of the
+dragged element) instead. Sources suppress that default via
+`suppressNativeDragGhost` (see `media-dnd.ts`) and this component renders our
+own preview instead: thumbnail above the cursor, count badge to its right.
+
+Mount once per page that hosts media drag sources.
+-->
+
+<script lang="ts">
+  import Badge from "@components/ui/badge.svelte";
+  import Portal from "@components/ui/portal.svelte";
+  import { dndState } from "@thisux/sveltednd";
+  import {
+    MEDIA_DRAG_CONTAINER,
+    suppressNativeDragGhost,
+    type MediaDragData,
+  } from "@utils/media/media-dnd";
+
+  const CARD_SIZE = 120;
+  const CARD_GAP = 12; // space between card bottom and cursor
+  const BADGE_GAP = 16; // space between cursor and badge (badge sits to the right)
+  const EDGE = 12;
+  const RETURN_MS = 200;
+
+  let cursorX = $state(0);
+  let cursorY = $state(0);
+  let hasPointer = $state(false);
+  let originX = $state(0);
+  let originY = $state(0);
+  /** Hide immediately after a valid drop, or after the cancel-return finishes. */
+  let dismissed = $state(false);
+  /** Animate back to the source item when released outside a drop target. */
+  let returning = $state(false);
+  let returnTimer: ReturnType<typeof setTimeout> | null = null;
+  // Snapshot while dragging — dndState clears on dragend before the return finishes.
+  let snapPreview = $state<MediaDragData["preview"]>(undefined);
+  let snapCount = $state(0);
+  /** True when the preview <img> 404s / fails — match grid's image-off placeholder. */
+  let imgFailed = $state(false);
+
+  const isActive = $derived(dndState.isDragging && dndState.sourceContainer === MEDIA_DRAG_CONTAINER);
+  const dragData = $derived(dndState.draggedItem as MediaDragData | null);
+
+  // Don't paint until we have a real pointer — avoids the top-left flash when
+  // sveltednd sets isDragging on pointerdown before the first move/dragover.
+  const visible = $derived((isActive && hasPointer && !dismissed) || returning);
+
+  function trackPointer(clientX: number, clientY: number) {
+    if (returning) return;
+    cursorX = clientX;
+    cursorY = clientY;
+    hasPointer = true;
+  }
+
+  function captureOrigin() {
+    const id = dragData?.ids?.[0];
+    if (!id || typeof document === "undefined") return;
+    const el = document.querySelector(`[data-media-id="${CSS.escape(id)}"]`);
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    originX = rect.left + rect.width / 2;
+    originY = rect.top + rect.height / 2;
+  }
+
+  function finish() {
+    returnTimer = null;
+    returning = false;
+    dismissed = true;
+    hasPointer = false;
+    snapPreview = undefined;
+    snapCount = 0;
+    imgFailed = false;
+  }
+
+  function onRelease() {
+    if (dismissed || returning) return;
+    // Click / aborted gesture with no real drag — nothing to animate.
+    if (!hasPointer) {
+      dismissed = true;
+      return;
+    }
+    // Valid folder/breadcrumb under the cursor → drop handled; hide immediately.
+    if (dndState.targetContainer) {
+      dismissed = true;
+      return;
+    }
+    // Cancelled: enable transition, then move to origin on the next frame so
+    // the browser interpolates from the drop point (same-tick updates skip CSS).
+    returning = true;
+    requestAnimationFrame(() => {
+      cursorX = originX;
+      cursorY = originY;
+      returnTimer = setTimeout(finish, RETURN_MS);
+    });
+  }
+
+  function onDragStart(event: DragEvent) {
+    // Capture phase on document — kills the native ghost (globe/icon) before
+    // any target handler can leave the browser's default drag image in place.
+    suppressNativeDragGhost(event);
+    trackPointer(event.clientX, event.clientY);
+  }
+
+  function onDragOver(event: DragEvent) {
+    trackPointer(event.clientX, event.clientY);
+    // Accept the drag everywhere while active so the browser doesn't play its
+    // own snap-back / "not allowed" cursor and delay dragend.
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    trackPointer(event.clientX, event.clientY);
+  }
+
+  $effect(() => {
+    if (!isActive) return;
+    dismissed = false;
+    returning = false;
+    hasPointer = false;
+    snapPreview = dragData?.preview;
+    snapCount = dragData?.ids?.length ?? 0;
+    imgFailed = false;
+    if (returnTimer) {
+      clearTimeout(returnTimer);
+      returnTimer = null;
+    }
+    captureOrigin();
+
+    document.addEventListener("dragstart", onDragStart, true);
+    document.addEventListener("dragover", onDragOver);
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("drop", onRelease, true);
+    document.addEventListener("pointerup", onRelease, true);
+    document.addEventListener("dragend", onRelease, true);
+
+    return () => {
+      document.removeEventListener("dragstart", onDragStart, true);
+      document.removeEventListener("dragover", onDragOver);
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("drop", onRelease, true);
+      document.removeEventListener("pointerup", onRelease, true);
+      document.removeEventListener("dragend", onRelease, true);
+    };
+  });
+
+  const cardX = $derived.by(() => {
+    if (typeof window === "undefined") return cursorX;
+    const half = CARD_SIZE / 2;
+    return Math.min(Math.max(cursorX, half + EDGE), window.innerWidth - half - EDGE);
+  });
+
+  const cardY = $derived.by(() => {
+    if (typeof window === "undefined") return cursorY;
+    return Math.min(Math.max(cursorY, CARD_SIZE + CARD_GAP + EDGE), window.innerHeight - EDGE);
+  });
+
+  const badgeX = $derived.by(() => {
+    if (typeof window === "undefined") return cursorX + BADGE_GAP;
+    return Math.min(cursorX + BADGE_GAP, window.innerWidth - EDGE);
+  });
+
+  const badgeY = $derived.by(() => {
+    if (typeof window === "undefined") return cursorY;
+    return Math.min(Math.max(cursorY, EDGE), window.innerHeight - EDGE);
+  });
+
+  function fileIcon(type: string | undefined): string {
+    switch (type) {
+      case "video":
+        return "fa-solid:video";
+      case "audio":
+        return "fa-solid:play-circle";
+      case "image":
+        return "mdi:image-off-outline";
+      default:
+        return "mdi:file-outline";
+    }
+  }
+
+  const showImage = $derived(
+    snapPreview?.type === "image" && !!snapPreview.url && !imgFailed,
+  );
+</script>
+
+{#if visible}
+  <Portal>
+    <div class="pointer-events-none fixed inset-0 z-[9999]" aria-hidden="true">
+      <!-- Thumbnail: rounded-lg like gallery tiles; no hard .card border (those look sharp mid-drag) -->
+      <div
+        class="media-checkerboard absolute overflow-hidden rounded-lg shadow-lg {returning
+          ? 'transition-[left,top] duration-200 ease-out'
+          : ''}"
+        style:left="{cardX}px"
+        style:top="{cardY}px"
+        style:width="{CARD_SIZE}px"
+        style:transform="translate(-50%, calc(-100% - {CARD_GAP}px))"
+      >
+        <div class="aspect-square w-full overflow-hidden">
+          {#if showImage}
+            <img
+              src={snapPreview?.url}
+              alt=""
+              class="h-full w-full object-cover"
+              draggable="false"
+              crossorigin="anonymous"
+              onerror={() => (imgFailed = true)}
+            />
+          {:else}
+            <div
+              class="flex h-full w-full items-center justify-center bg-surface-100/80 dark:bg-surface-800/80"
+            >
+              <iconify-icon
+                icon={fileIcon(snapPreview?.type)}
+                width="36"
+                class="text-surface-400 dark:text-surface-500"
+              ></iconify-icon>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <!-- Count bar: right of the cursor — warning yellow, button-like radius (not pill) -->
+      {#if snapCount > 0}
+        <div
+          class="absolute {returning ? 'transition-[left,top] duration-200 ease-out' : ''}"
+          style:left="{badgeX}px"
+          style:top="{badgeY}px"
+          style:transform="translateY(-50%)"
+        >
+          <Badge variant="warning" size="sm" rounded={false} class="normal-case tracking-normal">
+            {snapCount > 1 ? `+${snapCount - 1}` : "1 file"}
+          </Badge>
+        </div>
+      {/if}
+    </div>
+  </Portal>
+{/if}
+
+<style>
+  /* Same checkerboard as media-grid tiles so missing previews match the gallery. */
+  .media-checkerboard {
+    background-color: var(--color-surface-100);
+    background-image:
+      linear-gradient(45deg, var(--color-surface-200) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--color-surface-200) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--color-surface-200) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--color-surface-200) 75%);
+    background-size: 12px 12px;
+    background-position:
+      0 0,
+      0 6px,
+      6px -6px,
+      -6px 0;
+  }
+
+  :global(.dark) .media-checkerboard {
+    background-color: var(--color-surface-900);
+    background-image:
+      linear-gradient(45deg, var(--color-surface-800) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--color-surface-800) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--color-surface-800) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--color-surface-800) 75%);
+  }
+</style>

--- a/src/routes/(app)/mediagallery/media-grid.svelte
+++ b/src/routes/(app)/mediagallery/media-grid.svelte
@@ -17,10 +17,11 @@
   import MediaGridActionTooltip from "./media-grid-action-tooltip.svelte";
   import type { MediaBase, MediaImage } from "@utils/media/media-models";
   import {
-    beginMediaDrag,
-    endMediaDrag,
+    MEDIA_DRAG_CONTAINER,
     resolveMediaDragIds,
+    suppressNativeDragGhost,
   } from "@utils/media/media-dnd";
+  import { liftAndCarry } from "@utils/media/media-lift-drag";
   import { formatBytes } from "@utils/utils";
   import { SvelteSet } from "svelte/reactivity";
   import { fade, scale } from "svelte/transition";
@@ -49,9 +50,6 @@
     onOpenFileDetails = () => {},
   }: Props = $props();
 
-  /** Active drag count for card opacity feedback */
-  let draggingIds = $state(new SvelteSet<string>());
-
   const minColWidthCss = $derived(
     gridSize === "tiny"
       ? "clamp(88px, 22vw, 120px)"
@@ -66,6 +64,7 @@
   	let taggingFile = $state<MediaImage | null>(null);
   	let fileUploadInput = $state<HTMLInputElement>();
   	let failedImages = $state(new SvelteSet<string>());
+	let touchActiveId = $state<string | null>(null);
 
   const BATCH_SIZE = 60;
   let visibleCount = $state(BATCH_SIZE);
@@ -125,32 +124,6 @@
     } else {
       selectedFiles.add(fileId);
     }
-  }
-
-  function resolveFileId(file: MediaBase | MediaImage): string {
-    return file._id?.toString() || file.filename;
-  }
-
-  function handleDragStart(e: DragEvent, file: MediaBase | MediaImage) {
-    const target = e.target as HTMLElement | null;
-    // Don't start a media drag from interactive chrome (checkbox, action buttons)
-    if (target?.closest("[data-no-drag]")) {
-      e.preventDefault();
-      return;
-    }
-
-    const ids = resolveMediaDragIds(resolveFileId(file), selectedFiles);
-    const written = beginMediaDrag(e.dataTransfer, ids);
-    if (!written.length) {
-      e.preventDefault();
-      return;
-    }
-    draggingIds = new SvelteSet(written);
-  }
-
-  function handleDragEnd() {
-    draggingIds = new SvelteSet();
-    endMediaDrag();
   }
 
   function handleItemClick(file: MediaBase | MediaImage) {
@@ -228,6 +201,7 @@
   tabindex="-1"
   aria-label="Media asset grid"
   data-testid="media-grid"
+  ontouchstart={() => { touchActiveId = null; }}
 >
   {#if filteredFiles.length === 0}
     <div
@@ -268,23 +242,28 @@
     {#each visibleFiles as file (file._id || file.filename)}
       {const fileId = file._id?.toString() || file.filename}
       {const isSelected = selectedFiles.has(fileId)}
-      {const isDragging = draggingIds.has(fileId)}
 
       <div
         class="group relative flex h-full flex-col focus-within:outline-none cursor-grab active:cursor-grabbing
-          {isSelected ? 'ring-1 ring-inset ring-primary-500/50' : ''}
-          {isDragging ? 'opacity-50' : ''}"
+          {isSelected ? 'ring-1 ring-inset ring-primary-500/50' : ''}"
         role="gridcell"
         tabindex="-1"
         aria-selected={isSelected}
-        aria-grabbed={isDragging}
-        draggable="true"
-        ondragstart={(e) => handleDragStart(e, file)}
-        ondragend={handleDragEnd}
+        use:liftAndCarry={{
+          container: MEDIA_DRAG_CONTAINER,
+          dragData: {
+            ids: resolveMediaDragIds(fileId, selectedFiles),
+            preview: { filename: file.filename, url: file.type === 'image' ? file.url : undefined, type: file.type },
+          },
+          interactive: ['[data-no-drag]'],
+          attributes: { draggingClass: 'opacity-50' },
+        }}
+        ondragstart={suppressNativeDragGhost}
         title="Drag to a folder in the sidebar to move"
         data-testid="media-item"
         data-media-id={fileId}
         in:fade={{ duration: 180 }}
+        ontouchstart={(e) => { e.stopPropagation(); touchActiveId = fileId; }}
       >
         {#if isSelected}
           <div class="absolute inset-y-0 inset-s-0 z-10 w-0.5 bg-primary-500" aria-hidden="true"></div>
@@ -364,7 +343,7 @@
 
 
             <div
-              class="pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-linear-to-t from-black/75 via-black/30 to-transparent px-2.5 pb-2 pt-8 opacity-100 transition-opacity duration-200 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+              class="pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-linear-to-t from-black/75 via-black/30 to-transparent px-2.5 pb-2 pt-8 transition-opacity duration-200 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 {touchActiveId === fileId ? 'opacity-100' : 'opacity-0'}"
             >
               <p class="truncate text-[11px] font-medium leading-tight text-white" title={file.filename}>
                 {file.filename}
@@ -374,7 +353,7 @@
 
 
           <div
-            class="absolute inset-e-2 top-2 z-20 flex flex-col gap-1 opacity-100 transition-opacity duration-200 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+            class="absolute inset-e-2 top-2 z-20 flex flex-col gap-1 transition-opacity duration-200 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 {touchActiveId === fileId ? 'opacity-100' : 'opacity-0'}"
             data-no-drag
             data-testid="media-grid-actions"
           >

--- a/src/routes/(app)/mediagallery/media-table.svelte
+++ b/src/routes/(app)/mediagallery/media-table.svelte
@@ -13,6 +13,7 @@
 -->
 
 <script lang="ts">
+import { untrack } from "svelte";
 import { logger } from "@utils/logger";
 import {
 	createSmartTable,
@@ -28,14 +29,15 @@ import SmartTableShell from "@components/ui/smart-table/smart-table-shell.svelte
 import TagEditorModal from "@src/components/media/tag-editor/tag-editor-modal.svelte";
 import MediaTableRowMenu from "./media-table-row-menu.svelte";
 import type { MediaBase, MediaImage } from "@utils/media/media-models";
+import { draggable } from "@thisux/sveltednd";
 import {
-	beginMediaDrag,
-	endMediaDrag,
+	MEDIA_DRAG_CONTAINER,
 	resolveMediaDragIds,
+	suppressNativeDragGhost,
 } from "@utils/media/media-dnd";
+import { liftAndCarry } from "@utils/media/media-lift-drag";
 import { formatBytes } from "@utils/utils";
 import { SvelteSet } from "svelte/reactivity";
-import { untrack } from "svelte";
 import Checkbox from "@components/ui/checkbox.svelte";
 
 interface Props {
@@ -122,18 +124,22 @@ const smartTable = (() => {
   }
 })();
 
+// Columns are static — set once on mount, not reactive to filteredFiles
+smartTable.setColumns([
+	{ key: "_select", label: "", sortable: false, pin: "start", align: "center" },
+	{ key: "preview", label: "Preview", sortable: false, align: "start" },
+	{ key: "filename", label: "Name", sortable: true, align: "start" },
+	{ key: "size", label: "Size", sortable: true, align: "end" },
+	{ key: "type", label: "Type", sortable: true, align: "end" },
+	{ key: "_actions", label: "Actions", sortable: false, pin: "end", align: "end" },
+]);
+
 $effect(() => {
-	untrack(() => {
-		smartTable.setRows(filteredFiles as unknown as Record<string, unknown>[]);
-		smartTable.setColumns([
-			{ key: "_select", label: "", sortable: false, pin: "start", align: "center" },
-			{ key: "preview", label: "Preview", sortable: false, align: "start" },
-			{ key: "filename", label: "Name", sortable: true, align: "start" },
-			{ key: "size", label: "Size", sortable: true, align: "end" },
-			{ key: "type", label: "Type", sortable: true, align: "end" },
-			{ key: "_actions", label: "Actions", sortable: false, pin: "end", align: "end" },
-		]);
-	});
+	// Read outside untrack so the effect actually depends on filteredFiles —
+	// reading it only inside untrack leaves the effect with no dependencies and
+	// it would run once on mount, freezing the table on search/filter/upload.
+	const files = filteredFiles;
+	untrack(() => smartTable.setRows(files as unknown as Record<string, unknown>[]));
 });
 
 const paginatedFiles = $derived(smartTable.rows as unknown as (MediaBase | MediaImage)[]);
@@ -182,27 +188,6 @@ function toggleSelection(file: MediaBase | MediaImage) {
 	} else {
 		selectedFiles.add(fileId);
 	}
-}
-
-function resolveFileId(file: MediaBase | MediaImage): string {
-	return file._id?.toString() || file.filename;
-}
-
-function handleDragStart(e: DragEvent, file: MediaBase | MediaImage) {
-	const target = e.target as HTMLElement | null;
-	if (target?.closest("[data-no-drag]")) {
-		e.preventDefault();
-		return;
-	}
-	const ids = resolveMediaDragIds(resolveFileId(file), selectedFiles);
-	const written = beginMediaDrag(e.dataTransfer, ids);
-	if (!written.length) {
-		e.preventDefault();
-	}
-}
-
-function handleDragEnd() {
-	endMediaDrag();
 }
 
 function handleRowClick(file: MediaBase | MediaImage) {
@@ -263,7 +248,7 @@ function onUpdateRowsPerPage(rows: number) {
 					<div class="min-w-0 flex-1 text-[10px] font-semibold uppercase tracking-wider text-surface-500" role="columnheader">
 						Name
 					</div>
-					<div class="w-9 shrink-0 text-end text-[10px] font-semibold uppercase tracking-wider text-surface-500" role="columnheader">
+					<div class="w-16 shrink-0 text-end text-[10px] font-semibold uppercase tracking-wider text-surface-500" role="columnheader">
 						<span class="sr-only">Actions</span>
 					</div>
 				</div>
@@ -278,10 +263,17 @@ function onUpdateRowsPerPage(rows: number) {
 						role="row"
 						tabindex="0"
 						aria-selected={isSelected}
-						draggable="true"
+						use:liftAndCarry={{
+							container: MEDIA_DRAG_CONTAINER,
+							dragData: {
+								ids: resolveMediaDragIds(fileId, selectedFiles),
+								preview: { filename: file.filename, url: file.type === 'image' ? file.url : undefined, type: file.type },
+							},
+							interactive: ['[data-no-drag]'],
+							attributes: { draggingClass: 'opacity-50' },
+						}}
+						ondragstart={suppressNativeDragGhost}
 						title="Drag to a folder or breadcrumb to move"
-						ondragstart={(e) => handleDragStart(e, file)}
-						ondragend={handleDragEnd}
 						onclick={() => handleRowClick(file)}
 						onkeydown={(e) => handleKeyDown(e, file)}
 					>
@@ -393,10 +385,17 @@ function onUpdateRowsPerPage(rows: number) {
 							onkeydown={(e) => handleKeyDown(e, file)}
 							tabindex="0"
 							aria-selected={isSelected}
-							draggable="true"
+							use:draggable={{
+								container: MEDIA_DRAG_CONTAINER,
+								dragData: {
+									ids: resolveMediaDragIds(fileId, selectedFiles),
+									preview: { filename: file.filename, url: file.type === 'image' ? file.url : undefined, type: file.type },
+								},
+								interactive: ['[data-no-drag]'],
+								attributes: { draggingClass: 'opacity-50' },
+							}}
+							ondragstart={suppressNativeDragGhost}
 							title="Drag to a folder or breadcrumb to move"
-							ondragstart={(e) => handleDragStart(e, file)}
-							ondragend={handleDragEnd}
 						>
 							<td
 								class="media-table-select {SMART_TABLE_TD} {pinCellClass('start')} w-9 shrink-0 border-s-2! {isSelected ? 'border-s-primary-500!' : 'border-s-transparent!'}"

--- a/src/stores/media-folder-tree.svelte.ts
+++ b/src/stores/media-folder-tree.svelte.ts
@@ -86,9 +86,7 @@ class MediaFolderTreeStore {
   childrenOf(levelId: string): MediaFolderRecord[] {
     const list =
       levelId === "root"
-        ? this.folders.filter(
-            (f) => !f.parentId || !this.folders.some((p) => p.id === f.parentId),
-          )
+        ? this.folders.filter((f) => !f.parentId || !this.folders.some((p) => p.id === f.parentId))
         : this.folders.filter((f) => f.parentId === levelId);
     return [...list].sort((a, b) => a.order - b.order);
   }

--- a/src/stores/media-folder-tree.svelte.ts
+++ b/src/stores/media-folder-tree.svelte.ts
@@ -1,0 +1,116 @@
+/**
+ * @file src/stores/media-folder-tree.svelte.ts
+ * @description
+ * Shared flat list of media virtual folders for the sidebar tree and the
+ * mobile drag folder rail. One fetch, many consumers.
+ *
+ * ### Features:
+ * - cache-busted GET /api/system-virtual-folder
+ * - childrenOf / getFolder helpers for rail drill-in
+ * - event-driven refresh (folderCreated / Updated / Deleted)
+ */
+
+import { logger } from "@utils/logger";
+
+export interface MediaFolderRecord {
+  id: string;
+  name: string;
+  path: string;
+  parentId?: string | null;
+  order: number;
+}
+
+interface RawFolder {
+  _id: string;
+  name: string;
+  order?: number;
+  parentId?: string | null;
+  path: string;
+}
+
+class MediaFolderTreeStore {
+  folders = $state<MediaFolderRecord[]>([]);
+  isLoading = $state(false);
+  error = $state<string | null>(null);
+  /** A load has been attempted (success or failure) — see ensureLoaded. */
+  hasLoaded = $state(false);
+
+  /**
+   * Load once per session. Callers that only need the list to *exist* must use
+   * this, never `load()`: an empty result or a failed request both leave
+   * `folders` empty, so a `folders.length === 0` guard would re-fire forever
+   * inside a reactive effect.
+   */
+  async ensureLoaded(): Promise<void> {
+    if (this.hasLoaded || this.isLoading) return;
+    await this.load();
+  }
+
+  /**
+   * Fetch (or re-fetch) the flat folder list. Use for explicit refreshes
+   * (folder created/renamed/deleted); use ensureLoaded() for first paint.
+   * Cache-busts the API L1 cache so create/rename/delete appear immediately.
+   */
+  async load(): Promise<void> {
+    this.isLoading = true;
+    this.error = null;
+    try {
+      const res = await fetch(`/api/system-virtual-folder?t=${Date.now()}`);
+      if (!res.ok) throw new Error("Network error");
+      const { success, data } = await res.json();
+      if (!(success && data)) throw new Error("Invalid response");
+
+      this.folders = (data as RawFolder[])
+        .filter((f) => f.path?.startsWith("/"))
+        .map((f) => ({
+          id: f._id,
+          name: f.name,
+          path: f.path,
+          parentId: f.parentId,
+          order: f.order ?? 0,
+        }));
+    } catch (err) {
+      this.error = "Failed to load folders";
+      logger.error("[MediaFolderTree] Load error:", err);
+    } finally {
+      this.isLoading = false;
+      this.hasLoaded = true;
+    }
+  }
+
+  getFolder(id: string): MediaFolderRecord | undefined {
+    return this.folders.find((f) => f.id === id);
+  }
+
+  /** Direct children of a level. `root` = top-level orphans (no known parent). */
+  childrenOf(levelId: string): MediaFolderRecord[] {
+    const list =
+      levelId === "root"
+        ? this.folders.filter(
+            (f) => !f.parentId || !this.folders.some((p) => p.id === f.parentId),
+          )
+        : this.folders.filter((f) => f.parentId === levelId);
+    return [...list].sort((a, b) => a.order - b.order);
+  }
+
+  /** Parent folder id, or `root` when at the top. */
+  parentLevelOf(levelId: string): string {
+    if (levelId === "root") return "root";
+    const parentId = this.getFolder(levelId)?.parentId;
+    return parentId && this.getFolder(parentId) ? parentId : "root";
+  }
+
+  /** Root → … → level name chain for the rail path label. */
+  pathOf(levelId: string): MediaFolderRecord[] {
+    if (levelId === "root") return [];
+    const chain: MediaFolderRecord[] = [];
+    let current = this.getFolder(levelId);
+    while (current) {
+      chain.unshift(current);
+      current = current.parentId ? this.getFolder(current.parentId) : undefined;
+    }
+    return chain;
+  }
+}
+
+export const mediaFolderTree = new MediaFolderTreeStore();

--- a/src/utils/media/media-dnd.ts
+++ b/src/utils/media/media-dnd.ts
@@ -3,62 +3,76 @@
  * @description
  * Shared drag-and-drop helpers for moving media into virtual folders.
  *
- * Drop targets (equivalent on desktop and mobile):
- * - Left-sidebar virtual folder tree
- * - Gallery breadcrumb ancestors
+ * Drop targets are identical on desktop and mobile: the left-sidebar virtual
+ * folder tree plus the gallery breadcrumbs. On mobile the sidebar is the
+ * overlay drawer, which opens itself while a media drag is in flight
+ * (see media-drag-sidebar.svelte.ts) — there is no separate mobile DnD UI.
  *
- * Both call the same move API with the same multi-id payload.
+ * Transport is @thisux/sveltednd (use:draggable / use:droppable) — dragData
+ * travels in-memory via dndState, not a custom DataTransfer MIME type.
  *
  * ### Features:
- * - Custom MIME type isolated from folder reorder and OS file drops
  * - Windows-style multi-select drag payload
  * - Shared POST /api/media/move client for all drop targets
  */
 
-/** Custom MIME used by media grid/table → folder tree / breadcrumb drag operations */
-export const MEDIA_DND_MIME = "application/x-sveltycms-media-ids";
+/** Shared container id for all media drag sources (grid + table items). */
+export const MEDIA_DRAG_CONTAINER = "media-gallery-items";
 
-/** Document-level class while a media drag is active (optional CSS hooks) */
-export const MEDIA_DND_ACTIVE_CLASS = "media-dnd-active";
+/** Drop highlight: valid target folder (sidebar tree + breadcrumbs). */
+export const MEDIA_DROP_OK = "bg-primary-500/20 ring-1 ring-inset ring-primary-500/60";
+/** Drop highlight: files already live in this folder (drop is a no-op). */
+export const MEDIA_DROP_SAME = "bg-error-500/20 ring-1 ring-inset ring-error-500/60";
 
-export interface MediaDragPayload {
+export interface MediaDragPreview {
+  filename: string;
+  url?: string;
+  type?: string;
+}
+
+export interface MediaDragData {
   ids: string[];
+  preview?: MediaDragPreview;
+}
+
+// A 1×1 transparent canvas is a valid HTML5 drag image and, unlike an <img>,
+// needs no network fetch/decode — it's ready the instant it's created. A 0×0
+// canvas is NOT valid: browsers reject it and fall back to their own ghost
+// (on macOS often a small globe/document icon under the cursor).
+// Must live in the document — Chromium silently ignores setDragImage for
+// detached nodes and shows that same fallback icon.
+const emptyDragImage: HTMLCanvasElement | null = (() => {
+  if (typeof document === "undefined") return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+  canvas.setAttribute("aria-hidden", "true");
+  canvas.style.cssText =
+    "position:fixed;left:0;top:0;width:1px;height:1px;opacity:0;pointer-events:none;z-index:-1";
+  return canvas;
+})();
+
+/**
+ * Hides the browser's default HTML5 drag ghost (a screenshot of the dragged
+ * element, offset wherever the pointer happened to grab it). Wire to
+ * `ondragstart` alongside `use:draggable` so `MediaDragPreview` (a custom,
+ * cursor-anchored overlay) is the only visible drag image.
+ *
+ * Safe to call from a capture-phase `dragstart` listener (preferred) so it
+ * runs before any other handler can replace the drag image.
+ */
+export function suppressNativeDragGhost(event: DragEvent): void {
+  if (!event.dataTransfer || !emptyDragImage) return;
+  if (!emptyDragImage.isConnected) {
+    document.body.appendChild(emptyDragImage);
+  }
+  event.dataTransfer.setDragImage(emptyDragImage, 0, 0);
 }
 
 export interface MoveMediaResult {
   movedCount: number;
   fileIds: string[];
   targetFolderId: string | null;
-}
-
-export function serializeMediaDragPayload(ids: string[]): string {
-  const unique = [...new Set(ids.filter(Boolean))];
-  return JSON.stringify({ ids: unique } satisfies MediaDragPayload);
-}
-
-export function parseMediaDragPayload(raw: string | null | undefined): MediaDragPayload | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as MediaDragPayload;
-    if (!parsed || !Array.isArray(parsed.ids)) return null;
-    const ids = parsed.ids.filter((id): id is string => typeof id === "string" && id.length > 0);
-    return ids.length ? { ids } : null;
-  } catch {
-    return null;
-  }
-}
-
-/** True when the drag event carries our media payload (types list is available on dragover). */
-export function hasMediaDrag(dataTransfer: DataTransfer | null | undefined): boolean {
-  if (!dataTransfer) return false;
-  return Array.from(dataTransfer.types).includes(MEDIA_DND_MIME);
-}
-
-export function getMediaDragPayload(
-  dataTransfer: DataTransfer | null | undefined,
-): MediaDragPayload | null {
-  if (!dataTransfer) return null;
-  return parseMediaDragPayload(dataTransfer.getData(MEDIA_DND_MIME));
 }
 
 /**
@@ -75,59 +89,6 @@ export function resolveMediaDragIds(
     return [...new Set(selected)];
   }
   return [draggedId];
-}
-
-/**
- * Write the media move payload onto a DataTransfer and optional multi-item ghost.
- * Returns the ids written (empty if drag should be cancelled).
- */
-export function beginMediaDrag(
-  dataTransfer: DataTransfer | null | undefined,
-  ids: string[],
-): string[] {
-  const unique = [...new Set(ids.filter(Boolean))];
-  if (!dataTransfer || unique.length === 0) return [];
-
-  dataTransfer.effectAllowed = "move";
-  dataTransfer.setData(MEDIA_DND_MIME, serializeMediaDragPayload(unique));
-  // Fallback for environments that only expose text/plain during dragover
-  dataTransfer.setData("text/plain", unique.join(","));
-
-  // Optional multi-item drag ghost (best-effort; never fail the drag in tests/SSR)
-  if (
-    unique.length > 1 &&
-    typeof document !== "undefined" &&
-    typeof document.createElement === "function" &&
-    document.body &&
-    typeof dataTransfer.setDragImage === "function"
-  ) {
-    try {
-      const ghost = document.createElement("div");
-      ghost.textContent = `${unique.length} items`;
-      ghost.style.cssText =
-        "position:absolute;top:-9999px;padding:6px 10px;border-radius:8px;background:rgba(0,0,0,0.8);color:#fff;font:600 12px/1.2 system-ui,sans-serif;pointer-events:none;";
-      document.body.appendChild(ghost);
-      dataTransfer.setDragImage(ghost, 24, 16);
-      // setDragImage snapshots the node; remove synchronously (avoids rAF leaks in test runners)
-      if (typeof ghost.remove === "function") {
-        ghost.remove();
-      } else {
-        ghost.parentNode?.removeChild(ghost);
-      }
-    } catch {
-      // ignore — visual only
-    }
-  }
-
-  const root = typeof document !== "undefined" ? document.documentElement : null;
-  root?.classList?.add(MEDIA_DND_ACTIVE_CLASS);
-
-  return unique;
-}
-
-export function endMediaDrag(): void {
-  const root = typeof document !== "undefined" ? document.documentElement : null;
-  root?.classList?.remove(MEDIA_DND_ACTIVE_CLASS);
 }
 
 /**

--- a/src/utils/media/media-drag-sidebar.svelte.ts
+++ b/src/utils/media/media-drag-sidebar.svelte.ts
@@ -1,0 +1,59 @@
+/**
+ * @file src/utils/media/media-drag-sidebar.svelte.ts
+ * @description
+ * Opens the left-sidebar overlay drawer on mobile while a media drag is in
+ * flight, so the folder tree — the same drop target desktop uses — is reachable
+ * without a separate mobile DnD surface.
+ *
+ * The drawer's previous visibility is remembered and restored the moment the
+ * drag ends. On mobile that previous value is `hidden`, so a completed move
+ * closes the drawer by itself; a cancelled drag leaves the UI exactly as it was.
+ *
+ * ### Features:
+ * - single source of truth for drag-driven sidebar visibility
+ * - restore-on-end, so cancel and drop share one code path
+ */
+
+import { untrack } from "svelte";
+import { mediaFolderTree } from "@src/stores/media-folder-tree.svelte.ts";
+import { screen } from "@src/stores/screen-size-store.svelte.ts";
+import { ui, type UIVisibility } from "@src/stores/ui-store.svelte.ts";
+
+/**
+ * Wire the drawer to a media drag. Call once from a component's `<script>`;
+ * it installs an `$effect`, so it must run during component init.
+ *
+ * @param isMediaDragActive - reads the gallery's drag flag reactively
+ */
+export function useMediaDragSidebar(isMediaDragActive: () => boolean): void {
+  /** Visibility to put back when the drag ends; null when we haven't opened it. */
+  let restoreTo: UIVisibility | null = null;
+
+  // The drawer is unmounted on mobile until we open it, so its folder tree would
+  // otherwise start fetching mid-drag. Warm the shared store up front (deduped)
+  // so the drawer springs open already populated.
+  $effect(() => {
+    untrack(() => void mediaFolderTree.ensureLoaded());
+  });
+
+  $effect(() => {
+    const dragging = isMediaDragActive();
+    const isMobile = screen.isMobile;
+
+    // ui.state is written here and read on the next run — untrack keeps this
+    // effect depending on the drag flag alone rather than re-firing on itself.
+    untrack(() => {
+      if (dragging && isMobile) {
+        if (restoreTo === null) {
+          restoreTo = ui.state.leftSidebar;
+          ui.toggle("leftSidebar", "full");
+        }
+        return;
+      }
+      if (restoreTo !== null) {
+        ui.toggle("leftSidebar", restoreTo);
+        restoreTo = null;
+      }
+    });
+  });
+}

--- a/src/utils/media/media-lift-drag.ts
+++ b/src/utils/media/media-lift-drag.ts
@@ -1,0 +1,169 @@
+/**
+ * @file src/utils/media/media-lift-drag.ts
+ * @description
+ * Press-and-hold gate around sveltednd's `draggable` action for touch input.
+ *
+ * This is the *gesture* only — the drop targets are the ordinary sidebar folder
+ * tree and breadcrumbs, the same ones desktop uses. (An earlier mobile-only
+ * folder rail was removed; nothing here depends on it.)
+ *
+ * `draggable` starts a pointer drag on `pointerdown` and sets `touch-action: none`
+ * on the node, which makes a touch device unable to scroll a list of draggables.
+ * This action adds the press-and-hold gate the mobile UX needs, and then hands the
+ * gesture back to sveltednd untouched so drop detection, drag state and auto-scroll
+ * all stay the library's job — nothing here is reimplemented.
+ *
+ * Mouse/trackpad input is passed straight through to `draggable`, so desktop
+ * behaviour is byte-for-byte unchanged.
+ *
+ * ### Features:
+ * - hold-to-lift with movement cancel (a scroll gesture stays a scroll)
+ * - re-dispatches the real pointerdown so sveltednd drives the actual drag
+ * - keeps the node scrollable while idle (`touch-action` only set once lifted)
+ */
+
+import { draggable } from "@thisux/sveltednd";
+import type { DraggableOptions } from "@thisux/sveltednd";
+
+/** Press duration before the item lifts. Matches the mobile DnD prototype. */
+const HOLD_MS = 200;
+/** Movement (px) during the hold that cancels the lift and lets the list scroll. */
+const MOVE_CANCEL_PX = 10;
+
+/** Touch/pen input needs the hold gate; a mouse drags immediately as before. */
+function needsHoldGate(pointerType: string): boolean {
+  return pointerType === "touch" || pointerType === "pen";
+}
+
+/**
+ * Svelte action: `draggable` with a press-and-hold gate on touch input.
+ *
+ * @param node - element to make draggable
+ * @param options - forwarded verbatim to sveltednd's `draggable`
+ */
+export function liftAndCarry<T>(node: HTMLElement, options: DraggableOptions<T>) {
+  let current = options;
+  // Idle disabled so sveltednd leaves `touch-action` alone and the list scrolls.
+  const inner = draggable(node, { ...current, disabled: true });
+
+  let holdTimer: ReturnType<typeof setTimeout> | null = null;
+  let startX = 0;
+  let startY = 0;
+  let lifted = false;
+  /** Mouse input bypasses the gate for good; tracked apart from `lifted` so a
+   *  later touch on the same element still gets the hold gate on hybrid devices. */
+  let mousePassthrough = false;
+  let pending: PointerEvent | null = null;
+
+  function setInnerDisabled(disabled: boolean) {
+    inner.update({ ...current, disabled });
+  }
+
+  /** Block the browser's scroll/zoom once the item is lifted. */
+  function onTouchMove(event: TouchEvent) {
+    if (lifted) event.preventDefault();
+  }
+
+  function cancelHold() {
+    if (holdTimer) {
+      clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+    pending = null;
+  }
+
+  function lift() {
+    if (!pending) return;
+    const source = pending;
+    holdTimer = null;
+    pending = null;
+    lifted = true;
+
+    // Hand the gesture to sveltednd: enabling it and replaying the press makes
+    // the library's own handlePointerDown run for real, so drag state, drop
+    // dispatch and auto-scroll all come from the library rather than from here.
+    setInnerDisabled(false);
+    node.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        clientX: source.clientX,
+        clientY: source.clientY,
+        pointerId: source.pointerId,
+        pointerType: source.pointerType,
+        isPrimary: source.isPrimary,
+        button: 0,
+        buttons: 1,
+      }),
+    );
+
+    if (typeof navigator !== "undefined" && navigator.vibrate) navigator.vibrate(8);
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    if (current.disabled) return;
+    if (!needsHoldGate(event.pointerType)) {
+      // Mouse: hand straight over to sveltednd and leave it enabled.
+      if (!mousePassthrough) {
+        mousePassthrough = true;
+        setInnerDisabled(false);
+      }
+      return;
+    }
+    if (lifted) return;
+    // A touch after a mouse drag must re-arm the gate, or touch-action stays
+    // 'none' and the list can't be scrolled by finger again.
+    if (mousePassthrough) {
+      mousePassthrough = false;
+      setInnerDisabled(true);
+    }
+
+    startX = event.clientX;
+    startY = event.clientY;
+    pending = event;
+    holdTimer = setTimeout(lift, HOLD_MS);
+
+    document.addEventListener("pointermove", onPointerMove, { passive: true });
+    document.addEventListener("pointerup", onPointerUp);
+    document.addEventListener("pointercancel", onPointerUp);
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (lifted || !pending) return;
+    if (Math.hypot(event.clientX - startX, event.clientY - startY) > MOVE_CANCEL_PX) {
+      cancelHold();
+    }
+  }
+
+  function onPointerUp() {
+    cancelHold();
+    document.removeEventListener("pointermove", onPointerMove);
+    document.removeEventListener("pointerup", onPointerUp);
+    document.removeEventListener("pointercancel", onPointerUp);
+    if (!lifted) return;
+    // Re-arm after sveltednd's own pointerup handler has finished the drop.
+    setTimeout(() => {
+      lifted = false;
+      setInnerDisabled(true);
+    }, 0);
+  }
+
+  node.addEventListener("pointerdown", onPointerDown, { capture: true });
+  node.addEventListener("touchmove", onTouchMove, { passive: false });
+
+  return {
+    update(newOptions: DraggableOptions<T>) {
+      current = newOptions;
+      setInnerDisabled(!lifted && !mousePassthrough);
+    },
+    destroy() {
+      cancelHold();
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerup", onPointerUp);
+      document.removeEventListener("pointercancel", onPointerUp);
+      node.removeEventListener("pointerdown", onPointerDown, { capture: true });
+      node.removeEventListener("touchmove", onTouchMove);
+      inner.destroy();
+    },
+  };
+}

--- a/tests/e2e/routes/mediagallery/mediagallery.spec.ts
+++ b/tests/e2e/routes/mediagallery/mediagallery.spec.ts
@@ -250,14 +250,16 @@ test.describe("Media Gallery", () => {
   });
 
   test("grid size zoom changes thumbnail size", async ({ page }) => {
-    const sizeSelect = page.locator("#media-grid-size");
-    await expect(sizeSelect).toBeVisible({ timeout: 5_000 });
+    const gridSizeGroup = page.getByRole("group", { name: "Grid size" });
+    await expect(gridSizeGroup).toBeVisible({ timeout: 5_000 });
 
-    await sizeSelect.selectOption({ label: "Large" });
-    await expect(sizeSelect).toHaveValue("large");
+    const largeBtn = gridSizeGroup.getByRole("button", { name: "large grid" });
+    await largeBtn.click();
+    await expect(largeBtn).toHaveAttribute("aria-pressed", "true");
 
-    await sizeSelect.selectOption({ label: "Tiny" });
-    await expect(sizeSelect).toHaveValue("tiny");
+    const tinyBtn = gridSizeGroup.getByRole("button", { name: "tiny grid" });
+    await tinyBtn.click();
+    await expect(tinyBtn).toHaveAttribute("aria-pressed", "true");
 
     // Grid should still be visible
     await expect(page.getByTestId("media-grid")).toBeVisible({ timeout: 5_000 });

--- a/tests/e2e/routes/mediagallery/move-remote.spec.ts
+++ b/tests/e2e/routes/mediagallery/move-remote.spec.ts
@@ -8,7 +8,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test, type Page } from "@playwright/test";
-import { loginAsAdmin } from "../../helpers/auth";
+import { dismissCookieBanner, loginAsAdmin } from "../../helpers/auth";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEST_IMAGE = path.join(__dirname, "..", "..", "testthumb.png");
@@ -20,6 +20,10 @@ async function openGallery(page: Page) {
   await expect(page.getByTestId("media-gallery-toolbar")).toBeVisible({
     timeout: ACTION_TIMEOUT,
   });
+  // This spec runs with a blank storageState (see test.use below), so the GDPR
+  // banner can still be present/overlapping the sidebar drop targets even after
+  // loginAsAdmin — dismiss it so later drags/clicks aren't intercepted by it.
+  await dismissCookieBanner(page);
 }
 
 async function createFolder(page: Page, name: string) {

--- a/tests/e2e/routes/mediagallery/move-remote.spec.ts
+++ b/tests/e2e/routes/mediagallery/move-remote.spec.ts
@@ -137,26 +137,26 @@ test.describe("Media move to folder", () => {
       .first();
     await expect(item).toBeVisible({ timeout: ACTION_TIMEOUT });
 
-    const folderDrop = page
+    const specificFolderDrop = page
       .locator(`[data-media-drop-target]`)
       .filter({ hasText: folderName })
-      .first()
-      .or(page.locator("[data-media-drop-target]").first());
+      .first();
+    const hasSpecificDrop = await specificFolderDrop
+      .isVisible({ timeout: 8_000 })
+      .catch(() => false);
 
-    const dropVisible = await folderDrop.isVisible({ timeout: 8_000 }).catch(() => false);
-    if (!dropVisible) {
+    let folderDrop = specificFolderDrop;
+    if (!hasSpecificDrop) {
       test.info().annotations.push({
         type: "note",
         description:
-          "No folder drop target in layout (sidebar tree hidden); breadcrumb move test is the primary control",
+          "No folder-specific drop target in layout (sidebar tree hidden); breadcrumb move test is the primary control",
       });
-      const anyDrop = page.locator("[data-media-drop-target]");
+      folderDrop = page.locator("[data-media-drop-target]").first();
       await expect(
-        anyDrop.first(),
+        folderDrop,
         "Expected at least one [data-media-drop-target] for media move",
       ).toBeVisible({ timeout: 5_000 });
-    } else {
-      await expect(folderDrop).toBeVisible({ timeout: 5_000 });
     }
 
     const moveApi = page.waitForResponse(

--- a/tests/e2e/routes/mediagallery/move-remote.spec.ts
+++ b/tests/e2e/routes/mediagallery/move-remote.spec.ts
@@ -13,7 +13,6 @@ import { loginAsAdmin } from "../../helpers/auth";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEST_IMAGE = path.join(__dirname, "..", "..", "testthumb.png");
 const ACTION_TIMEOUT = 25_000;
-const MEDIA_DND_MIME = "application/x-sveltycms-media-ids";
 
 async function openGallery(page: Page) {
   await loginAsAdmin(page);
@@ -126,7 +125,7 @@ test.describe("Media move to folder", () => {
     await expect(page.getByText(/moved/i).first()).toBeVisible({ timeout: ACTION_TIMEOUT });
   });
 
-  test("HTML5 drop onto sidebar/root media drop target", async ({ page }) => {
+  test("drag-and-drop onto sidebar/root media drop target (sveltednd)", async ({ page }) => {
     await openGallery(page);
     const folderName = `e2e_dnd_${Date.now().toString(36).slice(-6)}`;
     await createFolder(page, folderName);
@@ -154,7 +153,7 @@ test.describe("Media move to folder", () => {
       const anyDrop = page.locator("[data-media-drop-target]");
       await expect(
         anyDrop.first(),
-        "Expected at least one [data-media-drop-target] for HTML5 media move",
+        "Expected at least one [data-media-drop-target] for media move",
       ).toBeVisible({ timeout: 5_000 });
     } else {
       await expect(folderDrop).toBeVisible({ timeout: 5_000 });
@@ -165,35 +164,10 @@ test.describe("Media move to folder", () => {
       { timeout: ACTION_TIMEOUT },
     );
 
-    // Synthetic HTML5 DnD
-    await page.evaluate(
-      ({ mime, folderSelector }) => {
-        const itemEl = document.querySelector('[data-testid="media-item"]') as HTMLElement | null;
-        const target = document.querySelector(folderSelector) as HTMLElement | null;
-        if (!itemEl || !target) throw new Error("missing drag source or target");
-
-        const idAttr = itemEl.dataset?.mediaId || itemEl.getAttribute("data-media-id") || "";
-        const ids = [idAttr || "unknown"];
-        const dt = new DataTransfer();
-        dt.setData(mime, JSON.stringify({ ids }));
-        dt.setData("text/plain", ids.join(","));
-        dt.effectAllowed = "move";
-
-        itemEl.dispatchEvent(
-          new DragEvent("dragstart", { bubbles: true, cancelable: true, dataTransfer: dt }),
-        );
-        target.dispatchEvent(
-          new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }),
-        );
-        target.dispatchEvent(
-          new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }),
-        );
-        itemEl.dispatchEvent(
-          new DragEvent("dragend", { bubbles: true, cancelable: true, dataTransfer: dt }),
-        );
-      },
-      { mime: MEDIA_DND_MIME, folderSelector: `[data-media-drop-target]` },
-    );
+    // Real mouse-driven drag: @thisux/sveltednd listens to native dragstart/dragover/drop
+    // (dispatched by the browser off real pointer input), so a synthetic DataTransfer/
+    // DragEvent dispatch — as used pre-migration — no longer reflects how a drag begins.
+    await item.dragTo(folderDrop);
 
     const res = await moveApi.catch(() => null);
     if (res) {
@@ -201,7 +175,7 @@ test.describe("Media move to folder", () => {
     } else {
       test.info().annotations.push({
         type: "note",
-        description: "Synthetic HTML5 drop did not hit move API; selection+breadcrumb covers move",
+        description: "Drag gesture did not hit move API; selection+breadcrumb covers move",
       });
     }
   });

--- a/tests/unit/utils/media-dnd.test.ts
+++ b/tests/unit/utils/media-dnd.test.ts
@@ -1,21 +1,14 @@
 /**
  * @file tests/unit/utils/media-dnd.test.ts
- * @description Unit tests for media drag-and-drop payload helpers.
+ * @description Unit tests for media drag-and-drop helpers.
  *
  * Compatible with both Vitest and bun:test (via vitest shim) — avoid vi.stubGlobal.
+ * Drag transport itself (dragData in-memory via @thisux/sveltednd's dndState) is
+ * exercised by the mediagallery e2e suite, not here.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  MEDIA_DND_MIME,
-  beginMediaDrag,
-  getMediaDragPayload,
-  hasMediaDrag,
-  moveMediaToFolder,
-  parseMediaDragPayload,
-  resolveMediaDragIds,
-  serializeMediaDragPayload,
-} from "@utils/media/media-dnd";
+import { moveMediaToFolder, resolveMediaDragIds } from "@utils/media/media-dnd";
 
 describe("media-dnd", () => {
   const originalFetch = globalThis.fetch;
@@ -23,37 +16,6 @@ describe("media-dnd", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
-  });
-
-  it("serializes unique non-empty ids", () => {
-    const raw = serializeMediaDragPayload(["a", "b", "a", "", "c"]);
-    expect(JSON.parse(raw)).toEqual({ ids: ["a", "b", "c"] });
-  });
-
-  it("parses valid payload", () => {
-    expect(parseMediaDragPayload(serializeMediaDragPayload(["x", "y"]))).toEqual({
-      ids: ["x", "y"],
-    });
-  });
-
-  it("returns null for invalid payloads", () => {
-    expect(parseMediaDragPayload(null)).toBeNull();
-    expect(parseMediaDragPayload("")).toBeNull();
-    expect(parseMediaDragPayload("{not-json")).toBeNull();
-    expect(parseMediaDragPayload(JSON.stringify({ ids: [] }))).toBeNull();
-    expect(parseMediaDragPayload(JSON.stringify({ ids: [1, 2] }))).toBeNull();
-  });
-
-  it("detects mime type on DataTransfer.types", () => {
-    const dt = {
-      types: [MEDIA_DND_MIME, "text/plain"],
-      getData: (type: string) =>
-        type === MEDIA_DND_MIME ? serializeMediaDragPayload(["id-1"]) : "",
-    } as unknown as DataTransfer;
-
-    expect(hasMediaDrag(dt)).toBe(true);
-    expect(hasMediaDrag(null)).toBe(false);
-    expect(getMediaDragPayload(dt)).toEqual({ ids: ["id-1"] });
   });
 
   it("moveMediaToFolder posts and returns moved count", async () => {
@@ -92,21 +54,5 @@ describe("media-dnd", () => {
     expect(resolveMediaDragIds("b", ["a", "b", "c"])).toEqual(["a", "b", "c"]);
     expect(resolveMediaDragIds("z", ["a", "b"])).toEqual(["z"]);
     expect(resolveMediaDragIds("solo", [])).toEqual(["solo"]);
-  });
-
-  it("beginMediaDrag writes the multi-id payload", () => {
-    const store = new Map<string, string>();
-    const dt = {
-      effectAllowed: "none",
-      setData: (type: string, value: string) => {
-        store.set(type, value);
-      },
-      setDragImage: () => {},
-    } as unknown as DataTransfer;
-
-    const ids = beginMediaDrag(dt, ["x", "y", "x"]);
-    expect(ids).toEqual(["x", "y"]);
-    expect(store.get(MEDIA_DND_MIME)).toBe(serializeMediaDragPayload(["x", "y"]));
-    expect(dt.effectAllowed).toBe("move");
   });
 });


### PR DESCRIPTION
## Summary
- Migrate media drag-and-drop to sveltednd with spring-open and mouse passthrough for sidebar folder drops
- Add lift-and-carry drag preview (`media-drag-preview.svelte`) and sidebar drag state store (`media-drag-sidebar.svelte.ts`)
- Add media folder tree store (`media-folder-tree.svelte.ts`) for sidebar navigation state
- Fix image editor crop shape switching, controls layout, and icons
- Refactor media gallery table/grid rendering and folder handling

## Test plan
- [x] `bun run format --check`
- [x] `bun run lint`
- [x] `bun run check`
- [x] `bun run test:unit` (2992 tests passing)
- [x] `bun run build`
- [ ] CI (format/lint/check/unit/build/e2e/db-matrix) — pending on this PR