### PR TITLE
fix: invalidate roles list cache on testing-API role mutations and gu…

### DIFF
--- a/src/components/ui/floating-input.svelte
+++ b/src/components/ui/floating-input.svelte
@@ -157,9 +157,14 @@ function handlePaste(e: ClipboardEvent) {
 	value = newValue;
 
 	// Restore cursor position after the inserted text
+	// setSelectionRange is not supported on input types that do not allow
+	// text selection (email, number, date, ...) and throws InvalidStateError.
 	requestAnimationFrame(() => {
 		const newPos = start + sanitized.length;
-		input.setSelectionRange(newPos, newPos);
+		const selectionTypes = new Set(['text', 'search', 'url', 'tel', 'password', 'textarea']);
+		if (selectionTypes.has(input.type)) {
+			input.setSelectionRange(newPos, newPos);
+		}
 	});
 
 	e.stopPropagation();

--- a/src/routes/api/[...path]/handlers/testing.ts
+++ b/src/routes/api/[...path]/handlers/testing.ts
@@ -839,6 +839,10 @@ export async function handleTestingRoutes(
       if (collectionId === "roles") {
         const { invalidatePermissionCache } = await import("@src/databases/auth/permissions");
         invalidatePermissionCache();
+        // Also drop the roles LIST cache (1h TTL) so getCachedRoles re-fetches —
+        // otherwise hasPermissionWithRoles resolves an empty role set and denies.
+        const { invalidateRolesCache } = await import("@src/hooks/handle-authorization");
+        await invalidateRolesCache(tenantId);
       }
 
       const responseBody = result.success
@@ -876,6 +880,10 @@ export async function handleTestingRoutes(
       if (collectionId === "roles") {
         const { invalidatePermissionCache } = await import("@src/databases/auth/permissions");
         invalidatePermissionCache();
+        // Also drop the roles LIST cache (1h TTL) so getCachedRoles re-fetches —
+        // otherwise hasPermissionWithRoles resolves an empty role set and denies.
+        const { invalidateRolesCache } = await import("@src/hooks/handle-authorization");
+        await invalidateRolesCache(tenantId);
       }
 
       const responseBody = result.success
@@ -904,6 +912,14 @@ export async function handleTestingRoutes(
         bypassTenantCheck: true,
         permanent: true,
       });
+
+      // Role deletions must also drop both caches (see insert/update rationale).
+      if (collectionId === "roles") {
+        const { invalidatePermissionCache } = await import("@src/databases/auth/permissions");
+        invalidatePermissionCache();
+        const { invalidateRolesCache } = await import("@src/hooks/handle-authorization");
+        await invalidateRolesCache(tenantId);
+      }
 
       return rawResponse(
         {


### PR DESCRIPTION
### What
- `testing.ts`: role insert/update/delete in `/api/testing` now also invalidates the roles-list cache (1h TTL), fixing stale 403 "Role not found" denials in permission-enforcement E2E tests.
- `floating-input.svelte`: guard `setSelectionRange()` to selection-capable inputs — fixes `InvalidStateError` spam on email paste.

### Validation
Unit 2992 ✅ · Security 114 ✅ · Integration 614 ✅ · Pre-push gate 6/6 ✅