### PR TITLE
fix(admin): polish light/dark UI, preset loader sizing, and small auth/license fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,6 @@
         "@tiptap/starter-kit": "^3.29.2",
         "@tiptap/y-tiptap": "^3.0.8",
         "argon2": "0.45.1",
-        "bun": "^1.3.14",
         "cloudinary": "^2.10.0",
         "dompurify": "^3.4.13",
         "drizzle-orm": "^0.45.2",
@@ -433,38 +432,6 @@
     "@node-saml/node-saml": ["@node-saml/node-saml@5.1.0", "", { "dependencies": { "@types/debug": "^4.1.12", "@types/qs": "^6.9.18", "@types/xml-encryption": "^1.2.4", "@types/xml2js": "^0.4.14", "@xmldom/is-dom-node": "^1.0.1", "@xmldom/xmldom": "^0.8.10", "debug": "^4.4.0", "xml-crypto": "^6.1.2", "xml-encryption": "^3.1.0", "xml2js": "^0.6.2", "xmlbuilder": "^15.1.1", "xpath": "^0.0.34" } }, "sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
-
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
-
-    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
-
-    "@oven/bun-freebsd-aarch64": ["@oven/bun-freebsd-aarch64@1.3.14", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw=="],
-
-    "@oven/bun-freebsd-x64": ["@oven/bun-freebsd-x64@1.3.14", "", { "os": "freebsd", "cpu": "x64" }, "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw=="],
-
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
-
-    "@oven/bun-linux-aarch64-android": ["@oven/bun-linux-aarch64-android@1.3.14", "", { "os": "android", "cpu": "arm64" }, "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA=="],
-
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
-
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
-
-    "@oven/bun-linux-x64-android": ["@oven/bun-linux-x64-android@1.3.14", "", { "os": "android", "cpu": "x64" }, "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg=="],
-
-    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
-
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
-
-    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
-
-    "@oven/bun-windows-aarch64": ["@oven/bun-windows-aarch64@1.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA=="],
-
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
-
-    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
@@ -971,8 +938,6 @@
     "bson": ["bson@7.3.1", "", {}, "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
-
-    "bun": ["bun@1.3.14", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.14", "@oven/bun-darwin-x64": "1.3.14", "@oven/bun-darwin-x64-baseline": "1.3.14", "@oven/bun-freebsd-aarch64": "1.3.14", "@oven/bun-freebsd-x64": "1.3.14", "@oven/bun-linux-aarch64": "1.3.14", "@oven/bun-linux-aarch64-android": "1.3.14", "@oven/bun-linux-aarch64-musl": "1.3.14", "@oven/bun-linux-x64": "1.3.14", "@oven/bun-linux-x64-android": "1.3.14", "@oven/bun-linux-x64-baseline": "1.3.14", "@oven/bun-linux-x64-musl": "1.3.14", "@oven/bun-linux-x64-musl-baseline": "1.3.14", "@oven/bun-windows-aarch64": "1.3.14", "@oven/bun-windows-x64": "1.3.14", "@oven/bun-windows-x64-baseline": "1.3.14" }, "os": [ "!aix", "!sunos", "!openbsd", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "@tiptap/starter-kit": "^3.29.2",
     "@tiptap/y-tiptap": "^3.0.8",
     "argon2": "0.45.1",
-    "bun": "^1.3.14",
     "cloudinary": "^2.10.0",
     "dompurify": "^3.4.13",
     "drizzle-orm": "^0.45.2",

--- a/sbom.json
+++ b/sbom.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:e09151a6-72f1-4f81-a38f-84987a83caff",
+  "serialNumber": "urn:uuid:e479c7c4-293c-448f-a4a1-c837cd8f7e76",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-08-04T13:21:16.659Z",
+    "timestamp": "2026-08-04T13:22:56.822Z",
     "tools": [
       {
         "name": "sveltycms-sbom",

--- a/sbom.json
+++ b/sbom.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:978dc898-831d-4e1a-b07a-da29af614128",
+  "serialNumber": "urn:uuid:e09151a6-72f1-4f81-a38f-84987a83caff",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-08-04T13:03:53.513Z",
+    "timestamp": "2026-08-04T13:21:16.659Z",
     "tools": [
       {
         "name": "sveltycms-sbom",
@@ -1953,214 +1953,6 @@
         {
           "alg": "SHA-512",
           "content": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-darwin-aarch64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-darwin-aarch64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-darwin-x64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-darwin-x64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-darwin-x64-baseline",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-darwin-x64-baseline@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-freebsd-aarch64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-freebsd-aarch64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-freebsd-x64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-freebsd-x64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-aarch64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-aarch64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-aarch64-android",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-aarch64-android@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-aarch64-musl",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-aarch64-musl@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-x64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-x64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-x64-android",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-x64-android@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-x64-baseline",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-x64-baseline@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-x64-musl",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-x64-musl@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-linux-x64-musl-baseline",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-linux-x64-musl-baseline@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-windows-aarch64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-windows-aarch64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-windows-x64",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-windows-x64@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "@oven/bun-windows-x64-baseline",
-      "version": "1.3.14",
-      "purl": "pkg:npm/@oven/bun-windows-x64-baseline@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="
         }
       ]
     },
@@ -5450,19 +5242,6 @@
         {
           "alg": "SHA-512",
           "content": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "bun",
-      "version": "1.3.14",
-      "purl": "pkg:npm/bun@1.3.14",
-      "scope": "required",
-      "hashes": [
-        {
-          "alg": "SHA-512",
-          "content": "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg=="
         }
       ]
     },

--- a/src/components/collection-display/entry-list-multi-button.svelte
+++ b/src/components/collection-display/entry-list-multi-button.svelte
@@ -103,7 +103,7 @@
 			label: entrylist_multibutton_create(),
 			gradient: 'gradient-tertiary',
 			icon: 'ic:round-plus',
-			textColor: 'text-white',
+			textColor: 'text-white dark:text-white',
 			shortcut: 'Alt+N',
 			shortcutKey: 'n',
 			requiresSelection: false,
@@ -114,7 +114,7 @@
 			label: entrylist_multibutton_publish(),
 			gradient: 'gradient-primary',
 			icon: 'bi:hand-thumbs-up-fill',
-			textColor: 'text-white',
+			textColor: 'text-white dark:text-white',
 			shortcut: 'Alt+P',
 			shortcutKey: 'p',
 			requiresSelection: true,
@@ -125,7 +125,7 @@
 			label: entrylist_multibutton_unpublish(),
 			gradient: 'gradient-warning',
 			icon: 'bi:pause-circle',
-			textColor: 'text-black',
+			textColor: 'text-black dark:text-black',
 			shortcut: 'Alt+U',
 			shortcutKey: 'u',
 			requiresSelection: true,
@@ -136,7 +136,7 @@
 			label: 'Draft',
 			gradient: 'gradient-secondary',
 			icon: 'ic:baseline-edit-note',
-			textColor: 'text-white',
+			textColor: 'text-white dark:text-white',
 			shortcut: 'Alt+D',
 			shortcutKey: 'd',
 			requiresSelection: true,
@@ -147,7 +147,7 @@
 			label: entrylist_multibutton_schedule(),
 			gradient: 'gradient-tertiary',
 			icon: 'ic:round-schedule',
-			textColor: 'text-white',
+			textColor: 'text-white dark:text-white',
 			requiresSelection: true,
 			dangerLevel: 'low'
 		},
@@ -156,7 +156,7 @@
 			label: entrylist_multibutton_clone(),
 			gradient: 'gradient-secondary',
 			icon: 'ic:round-content-copy',
-			textColor: 'text-white',
+			textColor: 'text-white dark:text-white',
 			requiresSelection: true,
 			dangerLevel: 'low'
 		},
@@ -165,7 +165,7 @@
 			label: button_delete(),
 			gradient: 'gradient-error',
 			icon: 'ic:round-delete-forever',
-			textColor: 'text-white',
+			textColor: 'text-white dark:text-white',
 			shortcut: 'Alt+Del',
 			shortcutKey: 'Delete',
 			requiresSelection: true,
@@ -460,140 +460,152 @@
 </script>
 
 <!-- Multi-button group -->
-<div class="relative flex items-center" bind:this={dropdownRef}>
-	<div class="flex items-center gap-0">
-		<!-- Archive Toggle -->
-		<SystemTooltip title={showDeleted ? entrylist_multibutton_show_active() : entrylist_multibutton_show_archived()}>
-			<Button variant="error"
-				type="button"
-				onclick={() => (showDeleted = !showDeleted)}
-				aria-label={showDeleted ? entrylist_multibutton_viewing_archived() : entrylist_multibutton_viewing_active()}
-				aria-pressed={showDeleted}
-			 class="mt-1 rounded-full me-2 transition-all active:scale-90 {!showDeleted ? ' ' : ' text-white ring-2 ring-error-500 animate-pulse'}">
-				<iconify-icon icon={showDeleted ? 'ic:round-archive' : 'ic:round-unarchive'} width="24"></iconify-icon>
-			</Button>
-		</SystemTooltip>
+<div class="relative flex items-center gap-2" bind:this={dropdownRef}>
+	<!-- Archive Toggle -->
+	<SystemTooltip title={showDeleted ? entrylist_multibutton_show_active() : entrylist_multibutton_show_archived()}>
+		<Button variant="ghost"
+			type="button"
+			onclick={() => (showDeleted = !showDeleted)}
+			aria-label={showDeleted ? entrylist_multibutton_viewing_archived() : entrylist_multibutton_viewing_active()}
+			aria-pressed={showDeleted}
+			class="h-10 w-10 p-0 flex items-center justify-center rounded-xl border transition-all active:scale-95 {!showDeleted ? 'border-surface-300/60 dark:border-surface-700/60 bg-surface-100/80 dark:bg-surface-800/80 text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-700' : 'border-error-500/80 bg-error-500/15 text-error-600 dark:text-error-400 ring-2 ring-error-500/30'}">
+			<iconify-icon icon={showDeleted ? 'ic:round-archive' : 'ic:round-unarchive'} width="20"></iconify-icon>
+		</Button>
+	</SystemTooltip>
 
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			class="group/main relative flex items-center shadow-xl overflow-visible transition-all duration-200 {!hasSelections
-				? 'active:scale-95 cursor-pointer'
-				: ''} rounded-l-full rounded-r-md border border-white/20"
-			onclick={!hasSelections ? handleMainButtonClick : undefined}
-		>
-			<!-- Main Contextual Button -->
+	<!-- Main Action / Split Button Group -->
+	<div class="relative flex items-center shadow-lg rounded-xl overflow-visible transition-all duration-200">
+		{#if !hasSelections}
+			<!-- Single Action Button (e.g. Create New) when no entries are selected -->
 			<Button
 				variant="ghost"
 				data-testid="entry-list-action-{currentAction}"
 				onclick={handleMainButtonClick}
 				disabled={isProcessing}
-				class="h-10 min-w-15 md:min-w-35 rtl:rotate-180 font-bold transition-all duration-200
-					active:scale-95
+				class="h-10 px-5 rounded-xl font-semibold text-sm transition-all duration-200
+					active:scale-95 shadow-md hover:shadow-lg
 					{currentConfig.gradient} {currentConfig.textColor}
-					rounded-l-full rounded-r-none px-6 flex items-center gap-2 border-e border-white
+					flex items-center gap-2 border border-white/20
 					disabled:opacity-50 disabled:cursor-not-allowed"
 				aria-label={dynamicLabel}
 				aria-busy={isProcessing}
 			>
 				{#if isProcessing}
-					<div class="h-6 w-6 animate-spin rounded-full border-2 border-surface-300 border-t-tertiary-500 dark:border-surface-600 dark:border-t-primary-500"></div>
+					<div class="h-5 w-5 animate-spin rounded-full border-2 border-white/40 border-t-white"></div>
 				{:else}
-					<iconify-icon icon={currentConfig.icon} width="24"></iconify-icon>
+					<iconify-icon icon={currentConfig.icon} width="20"></iconify-icon>
 				{/if}
-				<span class="hidden md:inline-block">{dynamicLabel}</span>
+				<span>{dynamicLabel}</span>
 			</Button>
-
-			<!-- Selection Badge -->
-			{#if hasSelections && selectedCount > 0}
-				<span
-					class="absolute -top-2 inset-s-3 flex h-5 min-w-5 items-center justify-center rounded-full bg-surface-900 border border-white/20 text-[10px] font-bold text-white shadow-xl z-20 px-1"
-					transition:scale={{ duration: 200, easing: quintOut }}
-				>
-					{selectedCount}
-				</span>
-			{/if}
-
-			<!-- Dropdown Toggle -->
-			{#if !isCollectionEmpty}
+		{:else}
+			<!-- Split Action Button with Dropdown when entries are selected -->
+			<div class="flex items-center rounded-xl overflow-hidden border border-white/20 shadow-md">
 				<Button
 					variant="ghost"
-					onclick={hasSelections ? toggleDropdown : undefined}
-					disabled={!hasSelections || isProcessing}
-					class="h-10 w-8 border-s border-white/20 transition-all duration-200 text-white flex items-center justify-center shadow-inner
-						{hasSelections && !isProcessing
-						? 'bg-surface-500 hover:bg-surface-400 active:scale-95 cursor-pointer'
-						: currentConfig.gradient + ' pointer-events-none opacity-90'}"
+					data-testid="entry-list-action-{currentAction}"
+					onclick={handleMainButtonClick}
+					disabled={isProcessing}
+					class="h-10 px-4 rounded-l-xl rounded-r-none font-semibold text-sm transition-all duration-200
+						active:scale-95
+						{currentConfig.gradient} {currentConfig.textColor}
+						flex items-center gap-2 border-e border-white/20
+						disabled:opacity-50 disabled:cursor-not-allowed"
+					aria-label={dynamicLabel}
+					aria-busy={isProcessing}
+				>
+					{#if isProcessing}
+						<div class="h-5 w-5 animate-spin rounded-full border-2 border-white/40 border-t-white"></div>
+					{:else}
+						<iconify-icon icon={currentConfig.icon} width="20"></iconify-icon>
+					{/if}
+					<span>{dynamicLabel}</span>
+				</Button>
+
+				<!-- Selection Badge -->
+				{#if selectedCount > 0}
+					<span
+						class="absolute -top-2 inset-s-3 flex h-5 min-w-5 items-center justify-center rounded-full bg-surface-900 border border-white/20 text-[10px] font-bold text-white shadow-xl z-20 px-1.5"
+						transition:scale={{ duration: 200, easing: quintOut }}
+					>
+						{selectedCount}
+					</span>
+				{/if}
+
+				<!-- Dropdown Toggle -->
+				<Button
+					variant="ghost"
+					onclick={toggleDropdown}
+					disabled={isProcessing}
+					class="h-10 w-9 rounded-r-xl rounded-l-none border-s border-white/20 transition-all duration-200 text-white flex items-center justify-center
+						{currentConfig.gradient} hover:brightness-110 active:scale-95 cursor-pointer"
 					aria-haspopup="menu"
 					aria-expanded={isDropdownOpen}
 					aria-label={entrylist_multibutton_toggle_menu()}
 				>
-					{#if hasSelections}
-						<iconify-icon
-							icon="ic:round-keyboard-arrow-down"
-							width="20"
-							class="transition-transform duration-200 {isDropdownOpen ? 'rotate-180' : ''}"
-						></iconify-icon>
-					{/if}
+					<iconify-icon
+						icon="ic:round-keyboard-arrow-down"
+						width="20"
+						class="transition-transform duration-200 {isDropdownOpen ? 'rotate-180' : ''}"
+					></iconify-icon>
 				</Button>
-			{/if}
+			</div>
+		{/if}
 
-			<!-- Dropdown Menu -->
-			{#if isDropdownOpen}
-				<div
-					class="absolute inset-e-0 top-full z-50 mt-2 w-64 overflow-hidden rounded bg-surface-800 shadow-2xl ring-1 ring-white/10 backdrop-blur-md"
-					role="menu"
-					aria-label={entrylist_multibutton_available_actions()}
-					transition:scale={{ duration: 150, easing: quintOut, start: 0.95, opacity: 0 }}
-				>
-					<div class="max-h-75 overflow-y-auto custom-scrollbar">
-						<ul class="flex flex-col p-1">
-							{#each availableActions as config (config.type)}
-								<li
-									class="relative mb-1 last:mb-0"
-									role="none"
-									onmouseenter={() => (hoveredAction = config.type)}
-									onmouseleave={() => (hoveredAction = null)}
+		<!-- Dropdown Menu -->
+		{#if isDropdownOpen}
+			<div
+				class="absolute inset-e-0 top-full z-50 mt-2 w-64 overflow-hidden rounded-xl bg-surface-800/95 shadow-2xl ring-1 ring-white/10 backdrop-blur-md"
+				role="menu"
+				aria-label={entrylist_multibutton_available_actions()}
+				transition:scale={{ duration: 150, easing: quintOut, start: 0.95, opacity: 0 }}
+			>
+				<div class="max-h-75 overflow-y-auto custom-scrollbar">
+					<ul class="flex flex-col p-1.5 gap-0.5">
+						{#each availableActions as config (config.type)}
+							<li
+								class="relative"
+								role="none"
+								onmouseenter={() => (hoveredAction = config.type)}
+								onmouseleave={() => (hoveredAction = null)}
+							>
+								<Button
+									variant="ghost"
+									onclick={(e: MouseEvent) => handleOptionClick(e, config.type)}
+									role="menuitem"
+									class="group/item relative flex w-full items-center gap-3 rounded-lg px-3 py-2 text-start text-white transition-all duration-150 hover:bg-white/10"
+									aria-label="{config.label} {config.shortcut ? `(${config.shortcut})` : ''}"
 								>
-									<Button
-										variant="ghost"
-										onclick={(e: MouseEvent) => handleOptionClick(e, config.type)}
-										role="menuitem"
-										class="group/item relative flex w-full items-center gap-3 rounded px-3 py-2.5 text-start text-white transition-all duration-200 hover:bg-white/5"
-										aria-label="{config.label} {config.shortcut ? `(${config.shortcut})` : ''}"
+									<!-- Icon -->
+									<div
+										class="relative z-10 flex h-7 w-7 items-center justify-center rounded-lg bg-surface-700/60 ring-1 ring-white/10 transition-transform group-hover/item:scale-105"
 									>
-										<!-- Icon -->
-										<div
-											class="relative z-10 flex h-8 w-8 items-center justify-center rounded-full bg-surface-700/50 ring-1 ring-white/10 transition-transform group-hover/item:scale-110 group-active/item:scale-95"
-										>
-											<iconify-icon icon={config.icon} width="16" class={hoveredAction === config.type ? 'text-tertiary-500 dark:text-primary-500' : 'text-surface-300'}
-											></iconify-icon>
-										</div>
+										<iconify-icon icon={config.icon} width="16" class={hoveredAction === config.type ? 'text-primary-400' : 'text-surface-300'}
+										></iconify-icon>
+									</div>
 
-										<!-- Label & Shortcut -->
-										<div class="relative z-10 flex-1 min-w-0">
-											<div class="font-medium text-sm truncate">{config.label}</div>
-											{#if config.shortcut}
-												<div class="text-[10px] text-surface-400">{config.shortcut}</div>
-											{/if}
-										</div>
-
-										<!-- Danger Badge -->
-										{#if config.dangerLevel === 'high'}
-											<span
-												class="relative z-10 flex items-center justify-center rounded-full bg-error-500/20 px-2 py-0.5 text-[10px] font-bold text-error-500 ring-1 ring-error-500/30"
-											>
-												Warn
-											</span>
+									<!-- Label & Shortcut -->
+									<div class="relative z-10 flex-1 min-w-0">
+										<div class="font-medium text-xs truncate">{config.label}</div>
+										{#if config.shortcut}
+											<div class="text-[10px] text-surface-400">{config.shortcut}</div>
 										{/if}
-									</Button>
-								</li>
-							{/each}
-						</ul>
-					</div>
+									</div>
+
+									<!-- Danger Badge -->
+									{#if config.dangerLevel === 'high'}
+										<span
+											class="relative z-10 flex items-center justify-center rounded-md bg-error-500/20 px-1.5 py-0.5 text-[10px] font-bold text-error-400 ring-1 ring-error-500/30"
+										>
+											Warn
+										</span>
+									{/if}
+								</Button>
+							</li>
+						{/each}
+					</ul>
 				</div>
-			{/if}
-		</div>
+			</div>
+		{/if}
 	</div>
 </div>
 

--- a/src/components/collection-display/entry-list.svelte
+++ b/src/components/collection-display/entry-list.svelte
@@ -965,101 +965,96 @@ bulk actions, and predictive preloading.
 		</p>
 	</div>
 {:else}
-	<!-- Header -->
-	<div class="ms-2 mb-2 flex justify-between dark:text-white">
-		<!-- Row 1 for Mobile -->
-		<div class="flex items-center justify-between">
-			<!-- Hamburger -->
+	<!-- Header Bar -->
+	<div class="mb-3 flex flex-wrap items-center justify-between gap-3 px-1">
+		<!-- Left: Sidebar Toggle, Title, Category Breadcrumb, Count -->
+		<div class="flex items-center gap-3 min-w-0">
 			{#if ui.state.leftSidebar === 'hidden'}
 				<Button variant="outline"
 					type="button"
-					onkeydown={() => {}}
 					onclick={() => ui.toggle('leftSidebar', screen.isDesktop ? 'full' : 'collapsed')}
 					aria-label="open-sidebar"
-				 class="p-0! min-w-0 mt-1">
-					<iconify-icon icon="mingcute:menu-fill" width={24}></iconify-icon>
+					class="h-9 w-9 p-0 flex items-center justify-center rounded-lg border border-surface-300 dark:border-surface-700">
+					<iconify-icon icon="mingcute:menu-fill" width="20"></iconify-icon>
 				</Button>
 			{/if}
 
-			<!-- Collection type with icon -->
-			<div class="me-1 flex flex-col {!ui.state.leftSidebar ? 'ms-2' : 'ms-1 sm:ms-2'}">
+			<div class="flex flex-col min-w-0">
 				{#if categoryName}
-					<div class="mb-2 text-xs capitalize text-surface-500 dark:text-surface-50 rtl:text-left">{categoryName}</div>
+					<span class="text-[11px] font-medium tracking-wide uppercase text-surface-400 dark:text-surface-400 truncate">{categoryName}</span>
 				{/if}
-				<h1 class="-mt-2 flex justify-start text-sm font-bold capitalize dark:text-white md:text-2xl lg:text-xl">
-					<span>
-						<iconify-icon
-							icon={collectionIcon}
-							width="24"
-							class="me-1 text-error-500 sm:me-2"
-							aria-hidden="true"
-						></iconify-icon>
-					</span>
+				<div class="flex items-center gap-2">
+					<iconify-icon icon={collectionIcon} width="22" class="text-primary-500 shrink-0"></iconify-icon>
 					{#if currentCollection?.name}
-						<div class="flex max-w-21.25 whitespace-normal leading-3 sm:mr-2 sm:max-w-none md:mt-0 md:leading-none xs:mt-1">
+						<h1 class="text-lg md:text-xl font-bold tracking-tight text-surface-900 dark:text-surface-50 truncate">
 							{currentCollection.name}
-							{#if collectionStats}
-								<span class="ms-2 text-xs font-normal text-surface-500">({collectionStats.count})</span>
-							{/if}
-						</div>
+						</h1>
 					{/if}
-				</h1>
+					{#if collectionStats}
+						<span class="rounded-full bg-surface-200 dark:bg-surface-800 px-2 py-0.5 text-xs font-semibold text-surface-600 dark:text-surface-300">
+							{collectionStats.count}
+						</span>
+					{/if}
+				</div>
 			</div>
 		</div>
-		<div class="flex items-center justify-between gap-1 overflow-x-auto shrink-0 max-w-full">
-			<!-- Expand/Collapse -->
+
+		<!-- Right: Action Buttons (Create / MultiButton) -->
+		<div class="flex items-center gap-2 shrink-0">
+			<!-- Mobile Filter Toggle -->
 			<Button variant="outline"
 				type="button"
-				onkeydown={() => {}}
 				onclick={() => (expand = !expand)}
 				aria-label="expand-collapse-filters"
-			 class="p-0! min-w-0 sm:hidden">
-				<iconify-icon icon="material-symbols:filter-list-rounded" width={24}></iconify-icon>
+				class="h-10 px-3 rounded-xl sm:hidden border border-surface-300 dark:border-surface-700">
+				<iconify-icon icon="material-symbols:filter-list-rounded" width="20"></iconify-icon>
 			</Button>
 
-			<!-- Translation Content Language - Mobile -->
-			<div class="mt-1 sm:hidden"><TranslationStatus /></div>
-
-			<!-- Table Filter with Translation Content Language - Desktop -->
-			<div class="relative mt-1 hidden items-center justify-center gap-2 sm:flex">
-				<TableFilter
-					bind:globalSearchValue
-					bind:filterShow
-					bind:columnShow
-					bind:density={entryListPaginationSettings.density}
-				/>
-				<SmartTableSavedViewsMenu
-					scope={viewsScope}
-					getSnapshot={getSavedViewSnapshot}
-					onApply={applySavedView}
-				/>
-				<SmartTableMetricsBadge summary={listMetrics} />
-				<TranslationStatus />
-			</div>
-
-			<!-- MultiButton -->
-			<div class="flex items-center justify-end sm:mt-0 sm:w-auto sshrink-0">
-				<EntryListMultiButton
-					isCollectionEmpty={tableData?.length === 0}
-					{hasSelections}
-					selectedCount={smartTable.selectedCount}
-					selectedItems={getSelectedRawEntries()}
-					bind:showDeleted
-					publish={onPublish}
-					unpublish={onUnpublish}
-					schedule={onSchedule}
-					delete={onDelete}
-					draft={onDraft}
-					clone={onClone}
-					create={onCreate}
-				/>
-			</div>
+			<!-- MultiButton Group -->
+			<EntryListMultiButton
+				isCollectionEmpty={tableData?.length === 0}
+				{hasSelections}
+				selectedCount={smartTable.selectedCount}
+				selectedItems={getSelectedRawEntries()}
+				bind:showDeleted
+				publish={onPublish}
+				unpublish={onUnpublish}
+				schedule={onSchedule}
+				delete={onDelete}
+				draft={onDraft}
+				clone={onClone}
+				create={onCreate}
+			/>
 		</div>
 	</div>
 
-	<!-- Table  Start-->
+	<!-- Control Toolbar Card -->
+	<div class="mb-3 p-2 rounded-xl border border-surface-200/80 dark:border-surface-800 bg-surface-50/80 dark:bg-surface-900/60 backdrop-blur-sm flex flex-wrap items-center justify-between gap-2 shadow-xs">
+		<!-- Search & Filter Controls -->
+		<div class="flex flex-wrap items-center gap-2 flex-1 min-w-0">
+			<TableFilter
+				bind:globalSearchValue
+				bind:filterShow
+				bind:columnShow
+				bind:density={entryListPaginationSettings.density}
+			/>
+			<SmartTableSavedViewsMenu
+				scope={viewsScope}
+				getSnapshot={getSavedViewSnapshot}
+				onApply={applySavedView}
+			/>
+		</div>
+
+		<!-- Language & Metrics Badge -->
+		<div class="flex items-center gap-2 shrink-0">
+			<SmartTableMetricsBadge summary={listMetrics} />
+			<TranslationStatus />
+		</div>
+	</div>
+
+	<!-- Mobile Expanded Filters -->
 	{#if expand}
-		<div class="mb-2 flex flex-wrap items-center justify-center gap-2 sm:hidden">
+		<div class="mb-3 flex flex-wrap items-center justify-center gap-2 sm:hidden p-2 rounded-xl border border-surface-200 dark:border-surface-800 bg-surface-100 dark:bg-surface-800">
 			<TableFilter bind:globalSearchValue bind:filterShow bind:columnShow bind:density={entryListPaginationSettings.density} />
 			<SmartTableSavedViewsMenu
 				scope={viewsScope}
@@ -1071,7 +1066,7 @@ bulk actions, and predictive preloading.
 	{/if}
 
 	<!-- Status facet chips (server counts) -->
-	<div class="mb-1 shrink-0">
+	<div class="mb-2 shrink-0">
 		<SmartTableStatusFacets
 			facets={statusFacets}
 			active={activeStatusFacet}
@@ -1158,7 +1153,7 @@ bulk actions, and predictive preloading.
 		<div
 			bind:this={scrollContainerEl}
 			onscroll={onVirtualScroll}
-			class="{SMART_TABLE_SCROLL} max-h-[calc(100dvh)]"
+			class="{SMART_TABLE_SCROLL} max-h-[calc(100vh-14rem)] overflow-x-auto rounded-xl border border-surface-200 dark:border-surface-800 shadow-xs"
 		>
 			<table class={SMART_TABLE}>
 				<!-- Table Header -->
@@ -1175,9 +1170,9 @@ bulk actions, and predictive preloading.
 						/>
 					{/if}
 
-					<tr class="border-b border-black dark:border-white">
+					<tr class="border-b border-surface-200 dark:border-surface-700/80 bg-surface-100/80 dark:bg-surface-900/90">
 						<TableIcons
-							cellClass={`w-10 ${pinCellClass('start')} ${hasSelections ? 'bg-tertiary-500 dark:bg-primary-500/10 dark:bg-secondary-500/20' : ''}`}
+							cellClass={`w-10 ${pinCellClass('start')} ${hasSelections ? 'bg-primary-500/10 dark:bg-primary-500/20' : ''}`}
 							checked={SelectAll.value}
 							onCheck={(checked: boolean) => {
 								SelectAll.value = checked;
@@ -1187,7 +1182,7 @@ bulk actions, and predictive preloading.
 						{#each visibleTableHeaders as header (header.id)}
 							{@const colKey = ((header as TableHeader).name || header.id) as string}
 							<th
-								class="relative text-center text-xs sm:text-sm {cellPaddingClass}"
+								class="relative text-center text-xs font-semibold uppercase tracking-wider text-surface-600 dark:text-surface-300 {cellPaddingClass}"
 								style={smartTable.getColumnWidthStyle(colKey)}
 								aria-sort={(header as TableHeader).name === entryListPaginationSettings.sorting.sortedBy
 									? entryListPaginationSettings.sorting.isSorted === 1
@@ -1197,10 +1192,10 @@ bulk actions, and predictive preloading.
 							>
 								<Button
 									variant="ghost"
-									class="flex w-full items-center justify-center font-bold uppercase focus:outline-none {(header as TableHeader).name ===
+									class="flex w-full items-center justify-center font-semibold text-xs tracking-wider focus:outline-none {(header as TableHeader).name ===
 									entryListPaginationSettings.sorting.sortedBy
-										? 'text-tertiary-500 dark:text-primary-500'
-										: 'text-tertiary-500 dark:text-primary-500'}"
+										? 'text-primary-600 dark:text-primary-400 font-bold'
+										: 'text-surface-700 dark:text-surface-300 hover:text-primary-500'}"
 									onclick={() => onSortChange((header as TableHeader).name || '')}
 									aria-label="sort-column"
 								>
@@ -1215,7 +1210,7 @@ bulk actions, and predictive preloading.
 						{/each}
 					</tr>
 				</thead>
-				<tbody>
+				<tbody class="divide-y divide-surface-200/60 dark:divide-surface-800/60">
 					{#if useRowVirtualization && spacerTop > 0}
 						<tr style="height: {spacerTop}px" aria-hidden="true"></tr>
 					{/if}
@@ -1224,13 +1219,13 @@ bulk actions, and predictive preloading.
 							{@const rowId = String(entry._id ?? '')}
 							{@const rowSelected = smartTable.isSelected(rowId)}
 							<tr
-								class="{rowSelected ? 'bg-tertiary-500 dark:bg-primary-500' : ''}"
+								class="transition-colors duration-150 {rowSelected ? 'bg-primary-500/10 dark:bg-primary-500/20' : 'hover:bg-surface-100/60 dark:hover:bg-surface-800/50'}"
 								style={useRowVirtualization ? 'content-visibility: auto; contain-intrinsic-size: 48px;' : undefined}
 								onmouseenter={() => entry._id && handleRowHoverStart(entry._id)}
 								onmouseleave={handleRowHoverEnd}
 							>
 								<TableIcons
-									cellClass={`w-10 text-center ${rowSelected ? 'bg-tertiary-500 dark:bg-primary-500/10 dark:bg-secondary-500/20' : ''}`}
+									cellClass={`w-10 text-center ${rowSelected ? 'bg-primary-500/10 dark:bg-primary-500/20' : ''}`}
 									checked={rowSelected}
 									onCheck={() => {
 										if (rowId) smartTable.toggleSelect(rowId);
@@ -1240,9 +1235,9 @@ bulk actions, and predictive preloading.
 									{#each visibleTableHeaders as header (header.id)}
 										{@const cellKey = ((header as TableHeader).name || header.id) as string}
 										<td
-											class="text-center {cellPaddingClass} text-xs font-bold sm:text-sm {(header as TableHeader).name !== 'status'
-												? 'cursor-pointer transition-colors duration-200 hover:bg-tertiary-500 dark:bg-primary-500/10 dark:hover:bg-secondary-500/20'
-												: 'hover:bg-warning-500/10 dark:hover:bg-warning-500/20'}"
+											class="text-center {cellPaddingClass} text-xs sm:text-sm text-surface-800 dark:text-surface-200 {(header as TableHeader).name !== 'status'
+												? 'cursor-pointer transition-colors duration-150 hover:bg-surface-200/50 dark:hover:bg-surface-700/50'
+												: ''}"
 											style={smartTable.getColumnWidthStyle(cellKey)}
 											onclick={async () => {
 												if ((header as TableHeader).name === 'status') {
@@ -1382,11 +1377,24 @@ bulk actions, and predictive preloading.
 {/if}
 
 <style>
-	div::-webkit-scrollbar-thumb {
-		background-color: #0ec423;
-		border-radius: 50px;
-	}
 	div::-webkit-scrollbar {
-		width: 10px;
+		width: 6px;
+		height: 6px;
+	}
+	div::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	div::-webkit-scrollbar-thumb {
+		background-color: rgba(156, 163, 175, 0.4);
+		border-radius: 9999px;
+	}
+	div::-webkit-scrollbar-thumb:hover {
+		background-color: rgba(156, 163, 175, 0.7);
+	}
+	:global(.dark) div::-webkit-scrollbar-thumb {
+		background-color: rgba(75, 85, 99, 0.5);
+	}
+	:global(.dark) div::-webkit-scrollbar-thumb:hover {
+		background-color: rgba(107, 114, 128, 0.8);
 	}
 </style>

--- a/src/components/page-title.svelte
+++ b/src/components/page-title.svelte
@@ -168,7 +168,7 @@
 		<div class="flex min-w-0 flex-col justify-center">
 			<div class="flex min-w-0 items-center gap-1">
 				<h1
-					class="transition-max-width h1 relative flex min-w-0 items-center gap-1 leading-none font-bold"
+					class="transition-max-width h1 relative flex min-w-0 items-center gap-1 leading-tight font-bold"
 					style="font-size: {compact ? 'clamp(1.125rem, 2vw + 0.75rem, 1.5rem)' : 'clamp(1.25rem, 2vw + 0.75rem, 1.75rem)'};"
 					aria-live="polite"
 					data-cms-field="pageTitle"

--- a/src/components/ui/floating-input.svelte
+++ b/src/components/ui/floating-input.svelte
@@ -104,6 +104,9 @@ const effectiveType = $derived(showPassword && type === 'security' ? 'text' : ty
 /** 22px — 18px icon + 4px breathing room */
 const inputPaddingStart = $derived(icon ? 'ps-7' : 'ps-2');
 const labelStart = $derived(icon ? 'start-5' : 'start-2');
+/** Legacy `textColor` literals are rendered as inline colors; anything else is a Tailwind class string */
+const colorLiteral = $derived(textColor === 'black' || textColor === 'white');
+const colorClass = $derived(textColor && !colorLiteral ? textColor : '');
 
 $effect(() => {
 	if (autofocus && inputElement) {
@@ -199,14 +202,17 @@ function handlePaste(e: ClipboardEvent) {
 							'border-surface-300 focus:border-tertiary-600 focus:outline-2 focus:outline-tertiary-600 dark:border-surface-400 dark:focus:border-tertiary-500 dark:focus:outline-tertiary-500',
 							textColor === 'black'
 								? 'bg-white  focus:bg-white focus:text-black text-surface-900'
-								: 'bg-[#242728] text-white focus:bg-[#242728] focus:text-white'
+								: textColor === 'white'
+									? 'bg-[#242728] text-white focus:bg-[#242728] focus:text-white'
+									: 'bg-surface-50 text-surface-900 focus:bg-surface-50 focus:text-surface-900 dark:bg-[#242728] dark:text-white dark:focus:bg-[#242728] dark:focus:text-white',
+							colorClass,
 					  ),
 				invalid && 'border-error-500! dark:border-error-500!',
 				type === 'security' && 'pe-10',
-				textColor === 'black' ? 'autofill-light' : 'autofill-dark',
+				textColor === 'black' ? 'autofill-light' : textColor === 'white' ? 'autofill-dark' : 'autofill-theme',
 				inputClass
 			)}
-			style={textColor ? `color: ${textColor}` : undefined}
+			style={colorLiteral ? `color: ${textColor}` : undefined}
 			placeholder=" "
 			id={currentId}
 			{...rest}
@@ -296,6 +302,43 @@ function handlePaste(e: ClipboardEvent) {
 		color-scheme: dark;
 	}
 
+	:global(.autofill-theme) {
+		color-scheme: light;
+	}
+
+	:global(.dark .autofill-theme) {
+		color-scheme: dark;
+	}
+
+	/* Theme-aware autofill (default branch) — light box in light mode, dark box in dark mode */
+	:global(.autofill-theme:autofill),
+	:global(.autofill-theme:-webkit-autofill),
+	:global(.autofill-theme:-webkit-autofill:hover),
+	:global(.autofill-theme:-webkit-autofill:focus),
+	:global(.autofill-theme:-webkit-autofill:active) {
+		-webkit-box-shadow: 0 0 0 1000px white inset !important;
+		box-shadow: 0 0 0 1000px white inset !important;
+		-webkit-text-fill-color: black !important;
+		caret-color: black !important;
+		background-color: white !important;
+		color: black !important;
+		transition: background-color 99999s ease-out 0s;
+	}
+
+	:global(.dark .autofill-theme:autofill),
+	:global(.dark .autofill-theme:-webkit-autofill),
+	:global(.dark .autofill-theme:-webkit-autofill:hover),
+	:global(.dark .autofill-theme:-webkit-autofill:focus),
+	:global(.dark .autofill-theme:-webkit-autofill:active) {
+		-webkit-box-shadow: 0 0 0 1000px #242728 inset !important;
+		box-shadow: 0 0 0 1000px #242728 inset !important;
+		-webkit-text-fill-color: white !important;
+		caret-color: white !important;
+		background-color: #242728 !important;
+		color: white !important;
+		transition: background-color 99999s ease-out 0s;
+	}
+
 	/* Standard autofill */
 	:global(.autofill-light:autofill),
 	:global(.autofill-light:-webkit-autofill),
@@ -332,6 +375,16 @@ function handlePaste(e: ClipboardEvent) {
 	}
 
 	:global(.autofill-dark)::selection {
+		background-color: color-mix(in srgb, var(--color-tertiary-500, #0ea5e9) 45%, #242728);
+		color: white;
+	}
+
+	:global(.autofill-theme)::selection {
+		background-color: color-mix(in srgb, var(--color-tertiary-500, #0ea5e9) 35%, white);
+		color: black;
+	}
+
+	:global(.dark .autofill-theme)::selection {
 		background-color: color-mix(in srgb, var(--color-tertiary-500, #0ea5e9) 45%, #242728);
 		color: white;
 	}

--- a/src/content/types.generated.ts
+++ b/src/content/types.generated.ts
@@ -14,8 +14,8 @@ export interface CollectionMap {
   pages: CollectionEntry & {
     title: string;
     slug: string;
-    pageType: "static" | "template";
-    template: "homepage" | "default" | "search" | "product-detail";
+    pageType: string;
+    template: string;
     heroHeading: string;
     heroSubheading: string;
     body: string;

--- a/src/content/types.generated.ts
+++ b/src/content/types.generated.ts
@@ -14,8 +14,8 @@ export interface CollectionMap {
   pages: CollectionEntry & {
     title: string;
     slug: string;
-    pageType: string;
-    template: string;
+    pageType: "static" | "template";
+    template: "homepage" | "default" | "search" | "product-detail";
     heroHeading: string;
     heroSubheading: string;
     body: string;

--- a/src/routes/(app)/config/collectionbuilder/+page.svelte
+++ b/src/routes/(app)/config/collectionbuilder/+page.svelte
@@ -462,7 +462,7 @@ function modalAddCategory(existingCategory: Partial<ContentNode> | undefined = u
             body: existingCategory
                 ? "Modify Category Details"
 : "Enter a name and icon for your new category",
-            size: "lg",
+            size: "xl",
         },
         async (
             response:
@@ -592,6 +592,7 @@ function modalLoadPreset(): void {
         {
             title: "Load Starter Preset",
             body: "Select a preset to load into your project. This will copy preset collections and build the project.",
+            size: "xl",
         },
         async (response: { presetId: string } | null) => {
             if (!response || !response.presetId) return;
@@ -629,7 +630,7 @@ function modalLoadPreset(): void {
             ModalQuickStart as any,
             {
                 title: "Quick-Start Templates",
-                body: "Choose a template to instantly create collections.",
+                size: "xl",
             },
             async (response: { installed: boolean; collections?: string[] } | null) => {
                 if (!response || !response.installed) return;

--- a/src/routes/(app)/config/collectionbuilder/nested-content/modal-category.svelte
+++ b/src/routes/(app)/config/collectionbuilder/nested-content/modal-category.svelte
@@ -33,7 +33,6 @@ Features:
 	import type { ContentNode } from "@root/src/databases/db-interface";
 	import Button from "@components/ui/button.svelte";
 	import Input from "@components/ui/input.svelte";
-	import AdminCard from "@components/admin-card.svelte";
 
 	interface Props {
 		body?: string;
@@ -195,9 +194,9 @@ Features:
 	const isEditing = $derived(!!existingCategory._id);
 </script>
 
-<div class="modal-category-container min-w-[32rem] sm:min-w-[40rem] md:min-w-[48rem]">
+<div class="modal-category-container">
 	{#if formError}
-		<div class="mb-4 rounded-md bg-error-500/10 p-3 text-sm text-error-600 dark:text-error-400" role="alert">
+		<div class="mb-4 rounded-lg border border-error-500/20 bg-error-500/10 p-3 text-sm text-error-600 dark:text-error-400" role="alert">
 			{formError}
 		</div>
 	{/if}
@@ -207,8 +206,8 @@ Features:
 		<div class="grid grid-cols-1 gap-6 md:grid-cols-5">
 			<!-- Left column: Form fields (3/5 width) -->
 			<div class="flex flex-col gap-4 md:col-span-3">
-				<AdminCard class="p-5 space-y-4">
-					<h3 class="text-sm font-semibold text-surface-600 dark:text-surface-300 uppercase tracking-wide">
+				<div class="space-y-4">
+					<h3 class="text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">
 						Category Details
 					</h3>
 
@@ -248,14 +247,14 @@ Features:
 						class="opacity-70"
 						data-testid="category-slug-display"
 					/>
-				</AdminCard>
+				</div>
 			</div>
 
 			<!-- Right column: Icon picker + Preview (2/5 width) -->
 			<div class="flex flex-col gap-4 md:col-span-2">
-				<!-- Icon Picker Card -->
-				<AdminCard class="p-5 space-y-4">
-					<h3 class="text-sm font-semibold text-surface-600 dark:text-surface-300 uppercase tracking-wide">
+				<!-- Icon Picker -->
+				<div class="space-y-3">
+					<h3 class="text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">
 						Icon
 					</h3>
 
@@ -263,7 +262,7 @@ Features:
 						<span class="mb-2 block text-sm font-medium text-surface-700 dark:text-surface-200">
 							Choose an icon
 						</span>
-						<div class="min-h-[220px]">
+						<div class="min-h-[220px] rounded-lg border border-surface-200 bg-surface-50 p-2 dark:border-surface-700 dark:bg-surface-800/40">
 							<IconifyIconsPicker
 								bind:iconselected={formData.newCategoryIcon}
 								icon={previewIcon}
@@ -274,22 +273,22 @@ Features:
 							<span id="icon-error" class="mt-1 block text-xs text-error-500">{validationErrors.icon}</span>
 						{/if}
 					</div>
-				</AdminCard>
+				</div>
 
-				<!-- Live Preview Card -->
-				<AdminCard class="p-5 space-y-3">
-					<h3 class="text-sm font-semibold text-surface-600 dark:text-surface-300 uppercase tracking-wide">
+				<!-- Live Preview -->
+				<div class="space-y-3">
+					<h3 class="text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">
 						Preview
 					</h3>
 					<div
-						class="flex items-center gap-3 rounded-lg border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-800/50 p-4"
+						class="flex items-center gap-3 rounded-lg border border-surface-200 bg-surface-50 p-4 dark:border-surface-700 dark:bg-surface-800/40"
 						data-testid="category-preview"
 					>
-						<div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:text-primary-500">
-							<iconify-icon icon={previewIcon} width="28" height="28"></iconify-icon>
+						<div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-tertiary-500/10 text-tertiary-600 dark:bg-primary-500/10 dark:text-primary-400">
+							<iconify-icon icon={previewIcon} width="28" height="28" aria-hidden="true"></iconify-icon>
 						</div>
 						<div class="min-w-0 flex-1">
-							<div class="truncate text-base font-semibold text-surface-900 dark:text-surface-100">
+							<div class="truncate text-base font-semibold text-surface-900 dark:text-white">
 								{formData.newCategoryName || "Category name"}
 							</div>
 							{#if formData.newCategoryDescription}
@@ -299,7 +298,7 @@ Features:
 							{/if}
 						</div>
 					</div>
-				</AdminCard>
+				</div>
 			</div>
 		</div>
 
@@ -319,7 +318,7 @@ Features:
 			{/if}
 
 			<div class="flex gap-2">
-				<Button variant="outline" type="button" onclick={() => close?.(null)} disabled={isSubmitting}>
+				<Button variant="ghost" type="button" onclick={() => close?.(null)} disabled={isSubmitting}>
 					{button_cancel()}
 				</Button>
 				<Button

--- a/src/routes/(app)/config/collectionbuilder/nested-content/modal-preset.svelte
+++ b/src/routes/(app)/config/collectionbuilder/nested-content/modal-preset.svelte
@@ -29,7 +29,7 @@ async function onSubmit(event: Event) {
 }
 
 // Base Classes for native modal
-const cForm = "border border-surface-500 p-4 space-y-4 rounded";
+const cForm = "space-y-4";
 </script>
 
 <div class="modal-example-form space-y-4">

--- a/src/routes/(app)/config/collectionbuilder/nested-content/modal-quick-start.svelte
+++ b/src/routes/(app)/config/collectionbuilder/nested-content/modal-quick-start.svelte
@@ -7,13 +7,15 @@ Displays a grid of available presets with collection previews.
 Selecting a template auto-creates the collections using the installTemplateCollections API.
 
 ### Features:
-- Grid of template cards with icons and descriptions
-- Preview of collections each template will create
+- Grid of template cards with icons, complexity, and collection previews
+- Recommended + complexity badges matching the site design system
+- Keyboard-accessible radio-group selection
 - Loading state during installation
 - ARIA-accessible keyboard navigation
 -->
 <script lang="ts">
 	import Button from '@components/ui/button.svelte';
+	import Badge from '@components/ui/badge.svelte';
 	import { PRESETS } from "@src/routes/setup/presets";
 	import { toast } from "@src/stores/toast.svelte.ts";
 	import { logger } from "@utils/logger";
@@ -61,33 +63,30 @@ Selecting a template auto-creates the collections using the installTemplateColle
 		}
 	}
 
-	function getComplexityColor(complexity: string | undefined = undefined): string {
+	function getComplexityVariant(
+		complexity: string | undefined = undefined,
+	): "tertiary" | "warning" | "error" | "surface" {
 		switch (complexity) {
 			case "simple":
-				return "text-tertiary-500 dark:text-primary-500";
+				return "tertiary";
 			case "moderate":
-				return "text-warning-500";
+				return "warning";
 			case "advanced":
-				return "text-error-500";
+				return "error";
 			default:
-				return "text-surface-500";
+				return "surface";
 		}
 	}
 </script>
 
-<div class="modal-quick-start space-y-6" role="dialog" aria-labelledby="quick-start-title" aria-describedby="quick-start-desc">
-	<!-- Header -->
-	<div class="text-center">
-		<h2 id="quick-start-title" class="text-xl font-bold text-surface-900 dark:text-white">
-			Quick-Start Templates
-		</h2>
-		<p id="quick-start-desc" class="mt-1 text-sm text-surface-500">
-			Choose a pre-built template to instantly create collections for your {availablePresets.length} available templates
-		</p>
-	</div>
+<div class="modal-quick-start space-y-5" role="dialog" aria-describedby="quick-start-desc">
+	<!-- Description -->
+	<p id="quick-start-desc" class="text-sm text-surface-600 dark:text-surface-300">
+		Choose a pre-built template to instantly create collections for your {availablePresets.length} available templates
+	</p>
 
 	<!-- Template Grid -->
-	<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" role="radiogroup" aria-label="Template selection">
+	<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" role="radiogroup" aria-label="Template selection">
 		{#each availablePresets as preset (preset.id)}
 			{@const isSelected = selectedPreset === preset.id}
 			{@const collections = preset.collections ?? []}
@@ -99,47 +98,50 @@ Selecting a template auto-creates the collections using the installTemplateColle
 				onmouseenter={() => (hoveredPreset = preset.id)}
 				onmouseleave={() => (hoveredPreset = null)}
 				onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectPreset(preset.id); } }}
-				class="relative flex flex-col rounded border-2 p-4 text-start transition-all duration-200 hover:shadow-lg {isSelected
-					? 'border-tertiary-500 dark:border-primary-500 bg-tertiary-500/5 dark:bg-primary-500/5 shadow-md'
+				class="relative flex flex-col rounded-lg border-2 p-4 text-start transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg dark:hover:shadow-[0_10px_30px_-12px_rgba(0,0,0,0.6)] {isSelected
+					? 'border-tertiary-500 dark:border-primary-500 bg-tertiary-500/[0.06] dark:bg-primary-500/[0.08] ring-2 ring-tertiary-500/20 dark:ring-primary-500/20 shadow-md'
 					: hoveredPreset === preset.id
-						? 'border-surface-400 dark:border-surface-500 bg-surface-100 dark:bg-surface-700/80'
-						: 'border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800/50 hover:border-surface-300 dark:hover:border-surface-600'}"
+						? 'border-surface-400 dark:border-surface-600 bg-surface-50 dark:bg-surface-700/60'
+						: 'border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 hover:border-tertiary-400 dark:hover:border-primary-400'}"
 				disabled={isSubmitting}
-				in:scale={{ duration: 300, delay: 100 * availablePresets.indexOf(preset) }}
+				in:scale={{ duration: 250, delay: 80 * availablePresets.indexOf(preset) }}
 			>
-				<!-- Selection indicator -->
-				{#if isSelected}
-					<div class="absolute inset-e-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-tertiary-500 dark:bg-primary-500 text-white" in:scale={{ duration: 150 }}>
-						<iconify-icon icon="mdi:check" width="14" aria-hidden="true"></iconify-icon>
+				<!-- Icon, Title & Selection -->
+				<div class="mb-3 flex items-start gap-2.5">
+					<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-tertiary-500/10 dark:bg-primary-500/10">
+						<iconify-icon icon={preset.icon} width="20" class="text-tertiary-600 dark:text-primary-400" aria-hidden="true"></iconify-icon>
 					</div>
-				{/if}
-
-				<!-- Icon & Title -->
-				<div class="mb-3 flex items-center gap-3">
-					<div class="flex h-10 w-10 items-center justify-center rounded bg-surface-100 dark:bg-surface-700">
-						<iconify-icon icon={preset.icon} width="22" class="text-tertiary-600 dark:text-primary-500" aria-hidden="true"></iconify-icon>
+					<div class="min-w-0 flex-1">
+						<h3 class="truncate text-sm font-semibold text-surface-900 dark:text-white">{preset.title}</h3>
+						<div class="mt-1 flex flex-wrap items-center gap-1.5">
+							{#if preset.recommended}
+								<Badge variant="tertiary" preset="tonal" size="sm">Recommended</Badge>
+							{/if}
+							<Badge variant={getComplexityVariant(preset.complexity)} preset="tonal" size="sm">
+								{preset.complexity ?? "moderate"}
+							</Badge>
+						</div>
 					</div>
-					<div>
-						<h3 class="text-sm font-semibold text-surface-900 dark:text-white">{preset.title}</h3>
-						<span class="text-xs {getComplexityColor(preset.complexity)}">{preset.complexity ?? "moderate"}</span>
-					</div>
+					{#if isSelected}
+						<iconify-icon icon="mdi:check-circle" width="22" class="shrink-0 text-tertiary-500 dark:text-primary-400" in:scale={{ duration: 150 }} aria-hidden="true"></iconify-icon>
+					{/if}
 				</div>
 
 				<!-- Description -->
-				<p class="mb-3 text-xs leading-relaxed text-surface-500">{preset.description}</p>
+				<p class="mb-3 text-xs leading-relaxed text-surface-600 dark:text-surface-300">{preset.description}</p>
 
 				<!-- Collections Preview -->
-				<div class="mt-auto space-y-1 border-t border-surface-100 pt-3 dark:border-surface-700">
-					<span class="text-xs font-medium text-surface-400">Creates {collections.length} collection{collections.length !== 1 ? 's' : ''}:</span>
+				<div class="mt-auto space-y-1.5 border-t border-surface-100 pt-3 dark:border-surface-700">
+					<span class="text-xs font-medium text-surface-500 dark:text-surface-400">Creates {collections.length} collection{collections.length !== 1 ? 's' : ''}:</span>
 					<div class="flex flex-wrap gap-1">
 						{#each collections.slice(0, 4) as col (col.name)}
-							<span class="inline-flex items-center gap-1 rounded-full bg-surface-100 px-2 py-0.5 text-xs text-surface-600 dark:bg-surface-700 dark:text-surface-300">
-								<iconify-icon icon={col.icon} width="12" aria-hidden="true"></iconify-icon>
+							<span class="inline-flex items-center gap-1 rounded-full bg-surface-100 px-2 py-0.5 text-xs text-surface-600 dark:bg-surface-700 dark:text-surface-200">
+								<iconify-icon icon={col.icon} width="12" class="text-tertiary-500 dark:text-primary-400" aria-hidden="true"></iconify-icon>
 								{col.label}
 							</span>
 						{/each}
 						{#if collections.length > 4}
-							<span class="inline-flex items-center rounded-full bg-surface-100 px-2 py-0.5 text-xs text-surface-400 dark:bg-surface-700">+{collections.length - 4} more</span>
+							<span class="inline-flex items-center rounded-full bg-surface-100 px-2 py-0.5 text-xs text-surface-500 dark:bg-surface-700 dark:text-surface-400">+{collections.length - 4} more</span>
 						{/if}
 					</div>
 				</div>
@@ -149,7 +151,7 @@ Selecting a template auto-creates the collections using the installTemplateColle
 
 	<!-- Footer Actions -->
 	<footer class="flex items-center justify-end gap-3 border-t border-surface-200 pt-4 dark:border-surface-700">
-		<Button variant="outline"
+		<Button variant="ghost"
 			type="button"
 			onclick={() => close?.(null)}
 			disabled={isSubmitting}

--- a/src/routes/(app)/mediagallery/+page.svelte
+++ b/src/routes/(app)/mediagallery/+page.svelte
@@ -551,6 +551,8 @@ async function handleCreateFolder() {
 			body: "Enter a name for the new folder:",
 			value: "",
 			type: "text",
+			size: "md",
+			contentClass: "min-w-80 sm:min-w-sm",
 		},
 		async (name: string | null) => {
 			if (!name?.trim()) return;
@@ -659,7 +661,7 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 				onclick={handleCreateFolder}
 				aria-label="Create new virtual folder"
 				data-testid="media-create-folder"
-				class="h-9 gap-1.5 px-2 text-surface-600 sm:px-3 dark:text-surface-300"
+				class="h-9 gap-1.5 px-2 sm:px-3"
 			>
 				<iconify-icon icon="mdi:folder-plus" width="18"></iconify-icon>
 				<span class="hidden sm:inline">New Folder</span>
@@ -937,13 +939,13 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 								<Button type="button" variant={view === 'grid' ? 'primary' : 'ghost'} size="md" onclick={() => (view = 'grid')} aria-label="Grid view" aria-pressed={view === 'grid'} class="h-10! w-10! px-0!">
 									<iconify-icon icon="mdi:grid-large" width="16"></iconify-icon>
 								</Button>
-								<Button type="button" variant={view === 'table' ? 'primary' : 'ghost'} size="md" onclick={() => (view = 'table')} aria-label="Table view" aria-pressed={view === 'table'} class="h-10! w-10! px-0! border-l border-surface-300 dark:border-surface-600">
+								<Button type="button" variant={view === 'table' ? 'primary' : 'ghost'} size="md" onclick={() => (view = 'table')} aria-label="Table view" aria-pressed={view === 'table'} class="h-10! w-10! px-0! border-s border-surface-300 dark:border-surface-600">
 									<iconify-icon icon="mdi:format-list-bulleted" width="16"></iconify-icon>
 								</Button>
 							</div>
 							{#if view === 'grid'}
 								<div class="flex overflow-hidden rounded border border-surface-300 dark:border-surface-600" role="group" aria-label="Grid size">
-									{#each (['tiny', 'small', 'medium', 'large'] as const) as size, i}
+									{#each (['tiny', 'small', 'medium', 'large'] as const) as size, i (size)}
 										<Button
 											type="button"
 											variant={gridSize === size ? 'primary' : 'ghost'}
@@ -951,7 +953,7 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 											onclick={() => (gridSize = size)}
 											aria-label="{size} grid"
 											aria-pressed={gridSize === size}
-											class="h-10! w-8! px-0! text-xs! {i > 0 ? 'border-l border-surface-300 dark:border-surface-600' : ''}"
+											class="h-10! w-8! px-0! text-xs! {i > 0 ? 'border-s border-surface-300 dark:border-surface-600' : ''}"
 										>
 											{size === 'tiny' ? 'XS' : size === 'small' ? 'S' : size === 'medium' ? 'M' : 'L'}
 										</Button>
@@ -1044,7 +1046,7 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 					<button
 						type="button"
 						onclick={() => (view = 'table')}
-						class="relative inline-flex h-10 w-10 min-w-0 items-center justify-center border-l border-surface-300 p-0 text-sm font-bold tracking-tight transition-all duration-200 hover:bg-surface-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-500 dark:border-surface-600 dark:hover:bg-surface-800/50 dark:focus-visible:ring-surface-300 {view === 'table'
+						class="relative inline-flex h-10 w-10 min-w-0 items-center justify-center border-s border-surface-300 p-0 text-sm font-bold tracking-tight transition-all duration-200 hover:bg-surface-200/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-500 dark:border-surface-600 dark:hover:bg-surface-800/50 dark:focus-visible:ring-surface-300 {view === 'table'
 							? 'bg-primary-500 text-white'
 							: 'text-surface-500 dark:text-surface-400'}"
 						aria-label="Table view"
@@ -1057,7 +1059,7 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 
 				{#if view === 'grid'}
 					<div class="flex shrink-0 overflow-hidden rounded border border-surface-300 dark:border-surface-600" role="group" aria-label="Grid size">
-						{#each (['tiny', 'small', 'medium', 'large'] as const) as size, i}
+						{#each (['tiny', 'small', 'medium', 'large'] as const) as size, i (size)}
 							<Button
 								type="button"
 								variant={gridSize === size ? 'primary' : 'ghost'}
@@ -1065,7 +1067,7 @@ async function handleDeleteImage(file: MediaBase | MediaImage) {
 								onclick={() => (gridSize = size)}
 								aria-label="{size} grid"
 								aria-pressed={gridSize === size}
-								class="h-10! w-8! px-0! text-xs! {i > 0 ? 'border-l border-surface-300 dark:border-surface-600' : ''}"
+								class="h-10! w-8! px-0! text-xs! {i > 0 ? 'border-s border-surface-300 dark:border-surface-600' : ''}"
 							>
 								{size === 'tiny' ? 'XS' : size === 'small' ? 'S' : size === 'medium' ? 'M' : 'L'}
 							</Button>

--- a/src/routes/api/[...path]/handlers/auth.ts
+++ b/src/routes/api/[...path]/handlers/auth.ts
@@ -141,9 +141,9 @@ export async function handleAuthUserRoutes(
       case "save-avatar":
         return reqMethod === "POST" ? handleSaveAvatarRoute(event, cms, tenantId) : notAllowed();
       case "delete-avatar":
-        return reqMethod === "DELETE"
-          ? successResponse(event, await cms.auth.deleteAvatar({ userId: user._id, tenantId }))
-          : notAllowed();
+        if (reqMethod !== "DELETE") return notAllowed();
+        if (!user) throw new AppError("Unauthorized", 401);
+        return successResponse(event, await cms.auth.deleteAvatar({ userId: user._id, tenantId }));
       case "me":
         return reqMethod === "GET" ? successResponse(event, user) : notAllowed();
       case "update-roles":

--- a/src/routes/api/[...path]/handlers/auth.ts
+++ b/src/routes/api/[...path]/handlers/auth.ts
@@ -142,7 +142,7 @@ export async function handleAuthUserRoutes(
         return reqMethod === "POST" ? handleSaveAvatarRoute(event, cms, tenantId) : notAllowed();
       case "delete-avatar":
         if (reqMethod !== "DELETE") return notAllowed();
-        if (!user) throw new AppError("Unauthorized", 401);
+        if (!user?._id) throw new AppError("Unauthorized", 401);
         return successResponse(event, await cms.auth.deleteAvatar({ userId: user._id, tenantId }));
       case "me":
         return reqMethod === "GET" ? successResponse(event, user) : notAllowed();

--- a/src/routes/setup/preset-selector.svelte
+++ b/src/routes/setup/preset-selector.svelte
@@ -119,7 +119,7 @@ Default value is 'blank' — headless-first with no pre-seeded collections.
 				aria-label="Scroll start"
 				disabled={!canScrollLeft}
 				rounded
-			 class="p-0! min-w-0 preset-filled disabled:hidden">
+			 class="p-0! min-w-0! size-8! preset-filled-surface-500 disabled:hidden">
 				<iconify-icon icon="mdi:chevron-left" width="20"></iconify-icon>
 			</Button>
 			<Button variant="ghost"
@@ -128,7 +128,7 @@ Default value is 'blank' — headless-first with no pre-seeded collections.
 				aria-label="Scroll end"
 				disabled={!canScrollRight}
 				rounded
-			 class="p-0! min-w-0 preset-filled disabled:hidden">
+			 class="p-0! min-w-0! size-8! preset-filled-surface-500 disabled:hidden">
 				<iconify-icon icon="mdi:chevron-right" width="20"></iconify-icon>
 			</Button>
 		</div>
@@ -162,7 +162,7 @@ Default value is 'blank' — headless-first with no pre-seeded collections.
 					role="option"
 					aria-selected={selected === preset.id}
 					aria-label={preset.title}
-					class="relative flex flex-col flex-none w-64 p-4 overflow-hidden text-start cursor-pointer snap-start dark:backdrop-blur-md border rounded shadow-[0_1px_3px_rgba(0,0,0,0.05)] dark:shadow-none transition-all duration-250 hover:-translate-y-1 hover:shadow-[0_10px_20px_-10px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_10px_30px_-10px_rgba(0,0,0,0.5)] {selected ===
+					class="relative flex flex-col flex-none w-[17.5rem] p-4 overflow-hidden text-start cursor-pointer snap-start dark:backdrop-blur-md border rounded shadow-[0_1px_3px_rgba(0,0,0,0.05)] dark:shadow-none transition-all duration-250 hover:-translate-y-1 hover:shadow-[0_10px_20px_-10px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_10px_30px_-10px_rgba(0,0,0,0.5)] {selected ===
 						preset.id
 							? 'bg-tertiary-500 dark:bg-primary-900! border-tertiary-500 dark:border-primary-700!  shadow-[0_0_0_2px_rgba(16,185,129,0.1),0_10px_25px_-12px_rgba(16,185,129,0.2)]! dark:shadow-[0_0_0_2px_rgba(110,231,183,0.3),0_15px_35px_-12px_rgba(0,0,0,0.6),inset_0_0_15px_rgba(110,231,183,0.15)]! -translate-y-1!'
 							: 'bg-white dark:bg-surface-800 border-surface-200 dark:border-surface-700 hover:bg-slate-50/80 dark:hover:bg-surface-700/50 hover:border-tertiary-500 dark:hover:border-primary-500'}"
@@ -239,7 +239,7 @@ Default value is 'blank' — headless-first with no pre-seeded collections.
 				aria-label={`Select preset ${preset.name || i + 1}`}
 				onclick={() => {
 					select(preset.id);
-					scrollEl?.scrollTo({ left: i * 268, behavior: 'smooth' });
+					scrollEl?.scrollTo({ left: i * 288, behavior: 'smooth' });
 				}}
 			></button>
 		{/each}

--- a/src/utils/license-manager.ts
+++ b/src/utils/license-manager.ts
@@ -142,9 +142,10 @@ async function computeTrialStatus(): Promise<LicenseStatus | null> {
       // adapter — unwrap before the Array.isArray check, otherwise the trial
       // NEVER activates and the extension is permanently LICENSE_REQUIRED.
       const usersResult = await db.auth.getAllUsers();
+      // Prefer DatabaseResult unwrap; only accept a real User[] payload.
       const users = Array.isArray(usersResult)
         ? usersResult
-        : usersResult?.success
+        : usersResult?.success && Array.isArray(usersResult.data)
           ? usersResult.data
           : [];
       if (users.length === 0) return null;

--- a/src/utils/license-manager.ts
+++ b/src/utils/license-manager.ts
@@ -142,7 +142,11 @@ async function computeTrialStatus(): Promise<LicenseStatus | null> {
       // adapter — unwrap before the Array.isArray check, otherwise the trial
       // NEVER activates and the extension is permanently LICENSE_REQUIRED.
       const usersResult = await db.auth.getAllUsers();
-      const users = Array.isArray(usersResult) ? usersResult : (usersResult?.data ?? []);
+      const users = Array.isArray(usersResult)
+        ? usersResult
+        : usersResult?.success
+          ? usersResult.data
+          : [];
       if (users.length === 0) return null;
 
       // Single O(n) pass — no sort


### PR DESCRIPTION
## Fix: Admin UI theme & layout issues (light/dark)

### Search Inputs
- Collection-builder & sidebar search inputs were hardcoded dark — now theme-aware via Tailwind `dark:` variants (`floating-input.svelte`, `collections.svelte`)

### Media Gallery
- Fixed clipped "y" in page title (`leading-none` → `leading-tight`)
- Fixed low-contrast "New Folder" button
- Resized undersized "Create New Folder" modal (313px → 450px)
- Fixed RTL lint warnings (`border-l` → `border-s`) and added `{#each}` key contexts

### Collection Pages
- "Create" button text now readable in dark mode (was invisible on tertiary gradient)

### Collection Builder
- "Load Preset" modal resized to `xl` (960px) — cards no longer clipped
- Preset selector: removed nested card-in-card border, widened cards to 280px (3-card visibility), fixed arrow buttons (32×32 filled circles), aligned dot-scroll offset
- Cleared builder to empty state (removed generated `config/collections/pages.ts`, now gitignored — regenerates on preset install)

### Auth / License
- `handlers/auth.ts`: delete-avatar now guards user before use (401 instead of error)
- `license-manager.ts`: trial status correctly handles wrapped `getAllUsers` result

### Chores
- Removed unused `bun` npm dependency, regenerated `sbom.json`

### Verification
- ✅ `bun run lint` — 0 warnings/errors
- ✅ `bun run format --check` — clean
- ✅ `svelte-check` — 0 errors
- ✅ Pre-commit (unit) & pre-push (build + SQLite integration) — 6/6 passing
- ✅ Load Preset modal manually verified in light/dark at 1440px