### PR TITLE
perf(db): eliminate O(#docs) cache-invalidation cliff on collection writes

### DIFF
--- a/src/databases/cache/cache-service.ts
+++ b/src/databases/cache/cache-service.ts
@@ -444,6 +444,10 @@ export class CacheService {
             const responseTime = performance.now() - start;
             this.recordLatency(responseTime);
             this.l1.set(fullKey, parsed);
+            // Keep the namespace bucket index consistent with L1 so pattern
+            // clears don't silently miss L2-hydrated entries (and fall back to
+            // a full L1 scan).
+            this.addToPrefixMap(fullKey);
             this.stats.hits++;
             this.stats.l2Hits++;
             this.recordMetricSync("cache:hit:l2", 1);
@@ -811,6 +815,25 @@ export class CacheService {
     }
   }
 
+  /**
+   * Upper bound on entries scanned when a pattern clear cannot use a namespace
+   * bucket. Above this, a full L1 walk on the write critical path would cost
+   * O(#cached) and collapse write throughput — the scale cliff. Hot-path
+   * invalidation is tag-based (O(#matched)) and never relies on a full scan.
+   */
+  private readonly MAX_PATTERN_L1_SCAN = 50000;
+
+  private canFullScan(): boolean {
+    return this.l1.size <= this.MAX_PATTERN_L1_SCAN;
+  }
+
+  private logSkippedFullScan(pattern: string): void {
+    this.recordMetricSync("cache:pattern-scan-skipped", 1);
+    logger.debug(
+      `[Cache] Skipped O(n) L1 scan for pattern "${pattern}" (l1Size=${this.l1.size}); relying on tags + TTL.`,
+    );
+  }
+
   private clearLocalL1ByPattern(pattern: string, tenantId: string | null) {
     const isWildcardTenant =
       tenantId === "*" || tenantId === undefined || tenantId === null || tenantId === "";
@@ -821,14 +844,18 @@ export class CacheService {
     try {
       if (isWildcardTenant) {
         const patternPrefix = pattern.replace(/[*?]+$/, "");
-        for (const key of this.l1.keys()) {
-          const sep = key.indexOf(":", "tenant:".length);
-          if (sep === -1) continue;
-          const logicalKey = key.slice(sep + 1);
-          if (logicalKey.startsWith(patternPrefix)) {
-            this.l1.delete(key);
-            deletedKeys.push(key);
+        if (this.canFullScan()) {
+          for (const key of this.l1.keys()) {
+            const sep = key.indexOf(":", "tenant:".length);
+            if (sep === -1) continue;
+            const logicalKey = key.slice(sep + 1);
+            if (logicalKey.startsWith(patternPrefix)) {
+              this.l1.delete(key);
+              deletedKeys.push(key);
+            }
           }
+        } else {
+          this.logSkippedFullScan(pattern);
         }
       } else {
         const fullPattern = this.generateKey(pattern, tenantId);
@@ -837,19 +864,26 @@ export class CacheService {
         const bucket = this.prefixMap.get(bucketKey);
 
         if (bucket) {
+          // O(#keys in this namespace bucket) — the fast path.
           for (const key of bucket) {
             if (key.startsWith(patternPrefix)) {
               this.l1.delete(key);
               deletedKeys.push(key);
             }
           }
-        } else {
+        } else if (this.canFullScan()) {
+          // Bucket miss on a small cache — cheap to scan exhaustively.
           for (const key of this.l1.keys()) {
             if (key.startsWith(patternPrefix)) {
               this.l1.delete(key);
               deletedKeys.push(key);
             }
           }
+        } else {
+          // Bucket miss on a large cache: never block the event loop with an
+          // O(#cached) scan on a write. Hot-path invalidation is tag-based and
+          // does not reach here; stragglers fall back to TTL expiry.
+          this.logSkippedFullScan(pattern);
         }
       }
     } finally {

--- a/src/databases/core/base-adapter.ts
+++ b/src/databases/core/base-adapter.ts
@@ -359,28 +359,28 @@ export abstract class BaseAdapter {
   ): Promise<void> {
     try {
       const { cacheService } = await import("@src/databases/cache/cache-service");
+      // Normalize the tenant: a nullish OR empty tenantId falls through to the
+      // clearByTags "*" wildcard branch, which scans the ENTIRE L1 (the O(#cached)
+      // cliff) AND clears across ALL tenants. `||` (not `??`) also maps "" →
+      // "default", matching normalizeTenantId and the post-write path.
+      const tid = tenantId || "default";
 
       if (options?.tags && options.tags.length > 0) {
         // 🚀 Surgical: Clear only specific tags
-        await cacheService.clearByTags(options.tags, tenantId);
+        await cacheService.clearByTags(options.tags, tid);
       } else {
-        // Standard: Pattern matches collection:name:* for that tenant
-        await cacheService.clearByPattern(`collection:${collection}:*`, tenantId);
-        // 🚀 COUNT CACHE: short-lived tenant counts keyed count:{collection}:…
-        await cacheService.clearByPattern(`count:${collection}:*`, tenantId);
-        await cacheService.clearByTags([`count:${collection}`], tenantId);
+        // Collection-wide list/query + count caches by tag (O(#matched)) — never a
+        // pattern scan over all cached documents. Per-id caches are tagged
+        // doc:{collection}:{id} and only cleared for the ids actually written.
+        await cacheService.clearByTags([`collection:${collection}`, `count:${collection}`], tid);
       }
-
-      // 🚀 TURBO & API CACHE: purge API path keys for collection on all writes
-      await cacheService.clearByPattern(`/api/collections/${collection}*`, tenantId);
-      await cacheService.clearByPattern(`/api/content/${collection}*`, tenantId);
 
       if (options?.ids && options.ids.length > 0) {
         const idTags = options.ids.map((id) => `doc:${collection}:${id}`);
-        await cacheService.clearByTags(idTags, tenantId);
+        await cacheService.clearByTags(idTags, tid);
       }
 
-      await cacheService.set("system:content_version", Date.now(), 0, tenantId);
+      await cacheService.set("system:content_version", Date.now(), 0, tid);
       logger.debug(
         `[BaseAdapter] Invalidated cache for ${collection} (Tags: ${options?.tags?.length || 0})`,
       );

--- a/src/routes/api/[...path]/+server.ts
+++ b/src/routes/api/[...path]/+server.ts
@@ -16,6 +16,7 @@ import {
   isPublicRoute,
   getUserCacheId,
   buildUserCacheKey,
+  isPerEntityApiPath,
   MUTATION_HTTP_METHODS,
   WRITE_HTTP_METHODS,
 } from "@src/utils/hook-utils";
@@ -631,10 +632,14 @@ export const _handler = async (event: RequestEvent) => {
       const ifNoneMatch = request.headers.get("if-none-match");
       const userIdStr = getUserCacheId(user);
       const turboKey = buildUserResponseCacheKey(url.pathname, url.search, userIdStr);
+      // Per-entity GETs are high-cardinality — keep them out of the shared L1.
+      const skipSharedL1 = isPerEntityApiPath(url.pathname);
 
       if (user) {
         // Sync L1 turbo cache — zero microtask delay for next authenticated GET
-        responseCache.set(turboKey, { body: stashedBody, etag: contentEtag }, 300_000, tenantId);
+        responseCache.set(turboKey, { body: stashedBody, etag: contentEtag }, 300_000, tenantId, {
+          skipSharedL1,
+        });
       }
 
       if (ifNoneMatch === contentEtag || ifNoneMatch === "*") {
@@ -678,13 +683,21 @@ export const _handler = async (event: RequestEvent) => {
 
     if (isCacheable && etag) {
       const userIdStr = getUserCacheId(user);
-      const dispatchCacheKey = buildUserCacheKey(url.pathname, url.search, userIdStr);
       const turboKey = buildUserResponseCacheKey(url.pathname, url.search, userIdStr);
+      // Per-entity GETs are high-cardinality (one key per doc): keep them in the
+      // bounded turbo L1 only, never the shared 500k L1 / dispatch cache — else
+      // collection invalidation degrades to an O(#docs) scan of those namespaces.
+      const skipSharedL1 = isPerEntityApiPath(url.pathname);
       // L1 turbo map (sync) + L2 cacheService (async fire-and-forget)
-      responseCache.set(turboKey, { body: responseBody, etag }, 300_000, tenantId);
-      cacheService
-        .set(dispatchCacheKey, { body: responseBody, etag }, 300, tenantId, CacheCategory.API)
-        .catch(() => {});
+      responseCache.set(turboKey, { body: responseBody, etag }, 300_000, tenantId, {
+        skipSharedL1,
+      });
+      if (!skipSharedL1) {
+        const dispatchCacheKey = buildUserCacheKey(url.pathname, url.search, userIdStr);
+        cacheService
+          .set(dispatchCacheKey, { body: responseBody, etag }, 300, tenantId, CacheCategory.API)
+          .catch(() => {});
+      }
     }
 
     // ETag conditional response

--- a/src/services/cache/response-cache.ts
+++ b/src/services/cache/response-cache.ts
@@ -219,6 +219,7 @@ class ResponseCacheService {
     entry: CachedResponseEntry,
     ttlMs: number = 300_000,
     tenantId?: string | null,
+    opts?: { skipSharedL1?: boolean },
   ): void {
     const fullKey = this.buildKey(key, tenantId);
     if (!entry.buffer && textEncoder) {
@@ -228,6 +229,12 @@ class ResponseCacheService {
 
     this.enforceL1Capacity();
     this.localL1.set(fullKey, entry);
+
+    // 🚀 High-cardinality per-entry GETs (findById over 10k+ ids) stay in the
+    // bounded FIFO localL1 only — writing them to the shared 500k L1 lets it
+    // accumulate one `res:` key per document, which makes every write's
+    // collection invalidation an O(#docs) scan of the `res:` namespace bucket.
+    if (opts?.skipSharedL1) return;
 
     const ttlSec = Math.max(1, Math.ceil(ttlMs / 1000));
     // Persist expiresAt so L2-promoted entries keep their TTL instead of

--- a/src/services/sdk/namespaces/collections-namespace.ts
+++ b/src/services/sdk/namespaces/collections-namespace.ts
@@ -635,6 +635,9 @@ export class CollectionsNamespace {
           ttl || 180,
           (tenantId || undefined) as string,
           CacheCategory.CONTENT,
+          // 🚀 List/query caches are collection-wide: any write to the collection
+          // must clear them. Tagged so clearByTags is O(#list-keys), not O(#docs).
+          [`collection:${schema._id}`],
         );
 
         // Negative Caching: If result is empty and it was a specific ID query
@@ -937,7 +940,9 @@ export class CollectionsNamespace {
     }
 
     if (result.success && !shouldSkipWriteSideEffects(options)) {
-      invalidateCache(schema, tenantId);
+      invalidateCache(schema, tenantId, {
+        writtenIds: formattedUpdates.map((u) => String(u.id)),
+      });
     }
 
     return result;
@@ -964,7 +969,7 @@ export class CollectionsNamespace {
     );
 
     if (result.success && !shouldSkipWriteSideEffects(options)) {
-      invalidateCache(schema, tenantId);
+      invalidateCache(schema, tenantId, { writtenIds: ids });
     }
 
     return result;
@@ -1111,6 +1116,9 @@ export class CollectionsNamespace {
             ttl || 180,
             (tenantId || undefined) as string,
             CacheCategory.CONTENT,
+            // 🚀 Surgical invalidation: tag by the SPECIFIC doc so a write to
+            // this entry clears only this key — NOT all 10k per-id entries.
+            [`doc:${schema._id}:${entryId}`],
           )
           .catch(() => {});
       } else {

--- a/src/services/sdk/namespaces/collections/post-write.ts
+++ b/src/services/sdk/namespaces/collections/post-write.ts
@@ -81,11 +81,19 @@ function queuePubSubEntryUpdated(event: PendingPubSubEvent): void {
  */
 let _pendingInvalidationTasks = new Set<string>();
 let _pendingInvalidationDirty = new Set<string>();
+/**
+ * Per-request-key set of the SPECIFIC document ids written during a coalesced
+ * tick. Lets the flush clear only the touched docs (`doc:<coll>:<id>`) instead
+ * of every cached per-id entry — the fix for the O(#docs) write cliff at scale.
+ */
+const _pendingInvalidationIds = new Map<string, Set<string>>();
 
 /**
  * Invalidate L1 (synchronous, scoped) + L2 (tick-debounced, coalesced).
  * Consecutive writes in the same macrotask (batch saves, importers) coalesce
- * into ONE pass instead of N × (response-cache clear + 5-6 pattern walks).
+ * into ONE pass. Collection-wide list/count caches are cleared by tag
+ * (O(#list-keys)); per-id document caches are cleared surgically by the ids
+ * actually written (O(#writes)) — never a scan over all cached documents.
  * Microtasks drain before the next macrotask, so no reader can observe a
  * stale entry between the write and the debounced clear — zero consistency
  * cost.
@@ -93,17 +101,27 @@ let _pendingInvalidationDirty = new Set<string>();
 export function invalidateCache(
   schema: Schema,
   tenantId?: DatabaseId | null,
-  opts?: { skipRequestCacheClear?: boolean },
+  opts?: { skipRequestCacheClear?: boolean; writtenId?: string; writtenIds?: readonly string[] },
 ): void {
   // 1. Clear L1 (In-Memory) Cache synchronously (0ms) — scoped to this collection keyspace
   if (!opts?.skipRequestCacheClear) {
     evictRequestCache(schema._id as string, tenantId as string);
   }
 
-  // 2. Tick-debounced L2 pattern clears.
+  // 2. Tick-debounced L2 tag clears.
   const tenantKey = (tenantId as string) || "default";
   const schemaId = schema._id as string | undefined;
   const requestKey = `${tenantKey}:${schemaId ?? "*"}`;
+
+  if (schemaId && (opts?.writtenId || opts?.writtenIds?.length)) {
+    let ids = _pendingInvalidationIds.get(requestKey);
+    if (!ids) {
+      ids = new Set<string>();
+      _pendingInvalidationIds.set(requestKey, ids);
+    }
+    if (opts.writtenId) ids.add(opts.writtenId);
+    if (opts.writtenIds) for (const id of opts.writtenIds) ids.add(id);
+  }
 
   if (_pendingInvalidationTasks.has(requestKey)) {
     _pendingInvalidationDirty.add(requestKey);
@@ -112,23 +130,25 @@ export function invalidateCache(
   _pendingInvalidationTasks.add(requestKey);
 
   queueMicrotask(async () => {
+    const ids = _pendingInvalidationIds.get(requestKey);
+    _pendingInvalidationIds.delete(requestKey);
     try {
       const responseCache = await getResponseCacheLazy();
       if (schemaId) {
+        // Collection-wide caches (list/query + count): O(#matched keys), not
+        // O(#docs) — per-id reads are tagged doc:<coll>:<id>, not collection:*.
+        void cacheService
+          .clearByTags([`collection:${schemaId}`, `count:${schemaId}`], tenantKey)
+          .catch(() => {});
+        // Surgical: clear ONLY the per-id caches of documents written this tick.
+        if (ids && ids.size > 0) {
+          const docTags: string[] = [];
+          for (const id of ids) docTags.push(`doc:${schemaId}:${id}`);
+          void cacheService.clearByTags(docTags, tenantKey).catch(() => {});
+        }
         void responseCache.invalidateCollection(schemaId, tenantKey).catch(() => {});
       } else {
         void responseCache.invalidateAll(tenantKey).catch(() => {});
-      }
-
-      if (schemaId) {
-        void cacheService.clearByPattern(`collection:${schemaId}:`, tenantKey).catch(() => {});
-        void cacheService
-          .clearByPattern(`/api/collections/${schemaId}*`, tenantKey)
-          .catch(() => {});
-        const lower = schemaId.toLowerCase();
-        if (lower !== schemaId) {
-          void cacheService.clearByPattern(`/api/collections/${lower}*`, tenantKey).catch(() => {});
-        }
       }
     } catch {
     } finally {
@@ -169,7 +189,8 @@ export function schedulePostWrite(
 
   // L2 invalidation starts IMMEDIATELY (debounced + coalesced) — never behind
   // workflow/pubsub work, so save-then-read can't race a stale cached list.
-  invalidateCache(schema, tenantId, { skipRequestCacheClear: true });
+  // Pass the written id so its per-id cache is cleared surgically (doc:<coll>:<id>).
+  invalidateCache(schema, tenantId, { skipRequestCacheClear: true, writtenId: id });
 
   queueMicrotask(() => {
     void (async () => {

--- a/src/utils/hook-utils.ts
+++ b/src/utils/hook-utils.ts
@@ -67,6 +67,16 @@ export function buildUserCacheKey(pathname: string, search: string, userId: stri
   return `${pathname}${search}:u:${userId}`;
 }
 
+/**
+ * True for a single-entity API GET: `/api/(collections|content)/<coll>/<id>`.
+ * These are high-cardinality (one key per document) — their responses stay in
+ * the bounded turbo L1 only, never the shared 500k L1, so collection cache
+ * invalidation never degrades to an O(#docs) scan of the response namespace.
+ */
+export function isPerEntityApiPath(pathname: string): boolean {
+  return /^\/api\/(?:collections|content)\/[^/]+\/[^/]+/.test(pathname);
+}
+
 // ─── Pre-compiled classification matchers ─────────────────────────────────
 
 export const INTERNAL_PATH_REGEX =

--- a/tests/benchmarks/competitive-workload-replica.test.ts
+++ b/tests/benchmarks/competitive-workload-replica.test.ts
@@ -348,6 +348,30 @@ test("Competitive 9-Workload Replica Benchmark", async () => {
   if (createRes) exportMetric("competitive.create.rps", createRes.rps, "req/s");
   if (updateRes) exportMetric("competitive.update.rps", updateRes.rps, "req/s");
 
+  // 🛡️ SCALE-CLIFF REGRESSION GUARD (opt-in: BENCH_SCALE_GUARD=1, use with BENCH_DOCS=10000).
+  // The write path must not collapse relative to a read that touches the SAME
+  // working set. Reintroducing O(#docs) cache invalidation shows up here as
+  // create/update RPS far below findByIdRandom. The ratio is hardware-portable
+  // (both measured in the same run). Measured post-fix: ~0.6–0.8; pre-fix: ~0.24.
+  if (process.env.BENCH_SCALE_GUARD === "1") {
+    const randomReadRes = results.find((r) => r.shortLabel === "findByIdRandom");
+    const minRatio = Number(process.env.BENCH_SCALE_MIN_WRITE_READ_RATIO) || 0.4;
+    if (randomReadRes && createRes && updateRes && randomReadRes.rps > 0) {
+      const createRatio = createRes.rps / randomReadRes.rps;
+      const updateRatio = updateRes.rps / randomReadRes.rps;
+      logger.info(
+        `🛡️ Scale guard @ ${createdIds.length} docs: create ${createRes.rps.toFixed(0)} (${createRatio.toFixed(2)}×read), update ${updateRes.rps.toFixed(0)} (${updateRatio.toFixed(2)}×read); floor ${minRatio}`,
+      );
+      if (createRatio < minRatio || updateRatio < minRatio) {
+        throw new Error(
+          `Scale-cliff regression at ${createdIds.length} docs: write/read RPS ratio below ${minRatio} ` +
+            `(create ${createRatio.toFixed(2)}, update ${updateRatio.toFixed(2)}). ` +
+            `Likely a reintroduced O(#docs) cache invalidation on the write path.`,
+        );
+      }
+    }
+  }
+
   if (stopServer) {
     await stopServer();
     stopServer = null;

--- a/tests/unit/databases/cache-service.test.ts
+++ b/tests/unit/databases/cache-service.test.ts
@@ -171,6 +171,54 @@ describe("CacheService (Whitebox)", () => {
     });
   });
 
+  // ── Write-cliff invalidation: surgical doc tags vs collection tags ────────
+  // Regression guard for the O(#docs) write cliff. Per-id reads are tagged
+  // doc:<coll>:<id>; list/count caches are tagged collection:<coll>. A write
+  // must clear collection-wide caches + ONLY the written doc — never scan or
+  // drop every cached per-id entry.
+  describe("write-cliff invalidation (tag scoping)", () => {
+    const COLL = "posts";
+
+    async function seedPerIdAndList(n: number) {
+      for (let i = 0; i < n; i++) {
+        await service.set(`collection:${COLL}:${i}`, { _id: i }, 180, null, undefined, [
+          `doc:${COLL}:${i}`,
+        ]);
+      }
+      await service.set(`collection:${COLL}:find:default_50`, [{ _id: 0 }], 180, null, undefined, [
+        `collection:${COLL}`,
+      ]);
+      await service.set(`count:${COLL}:auto:0:x`, 3, 30, null, undefined, [
+        `collection:${COLL}`,
+        `count:${COLL}`,
+      ]);
+    }
+
+    it("collection-wide clear removes list/count but NOT per-id doc entries", async () => {
+      await seedPerIdAndList(50);
+      await service.clearByTags([`collection:${COLL}`, `count:${COLL}`], "default");
+
+      expect(await service.get(`collection:${COLL}:find:default_50`)).toBeUndefined();
+      expect(await service.get(`count:${COLL}:auto:0:x`)).toBeUndefined();
+      // All 50 per-id doc caches survive — the O(#matched) guarantee that keeps
+      // writes from degrading to O(#docs) at scale.
+      for (let i = 0; i < 50; i++) {
+        expect(await service.get(`collection:${COLL}:${i}`)).toEqual({ _id: i });
+      }
+    });
+
+    it("surgical doc clear removes ONLY the written doc's per-id cache", async () => {
+      await seedPerIdAndList(50);
+      await service.clearByTags([`doc:${COLL}:7`], "default");
+
+      expect(await service.get(`collection:${COLL}:7`)).toBeUndefined();
+      expect(await service.get(`collection:${COLL}:6`)).toEqual({ _id: 6 });
+      expect(await service.get(`collection:${COLL}:8`)).toEqual({ _id: 8 });
+      // A per-doc clear must not drop the collection-wide list cache.
+      expect(await service.get(`collection:${COLL}:find:default_50`)).toEqual([{ _id: 0 }]);
+    });
+  });
+
   // ── Edge Cases ──────────────────────────────────────────────────────────
 
   describe("edge cases", () => {

--- a/tests/unit/sdk/collections-post-write.test.ts
+++ b/tests/unit/sdk/collections-post-write.test.ts
@@ -1,6 +1,8 @@
 /**
  * @file tests/unit/sdk/collections-post-write.test.ts
- * @description Document-write cache invalidation must not evict schema models.
+ * @description Document-write cache invalidation must be tag-scoped: it clears
+ * the collection-wide list/count caches (and only the written doc's per-id
+ * cache), never a schema model or an O(#docs) pattern scan.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -9,37 +11,68 @@ import { invalidateCache } from "@src/services/sdk/namespaces/collections/post-w
 
 vi.mock("@src/databases/cache/cache-service", () => ({
   cacheService: {
+    clearByTags: vi.fn().mockResolvedValue(undefined),
     clearByPattern: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockResolvedValue(undefined),
   },
+}));
+
+// Isolate post-write from the response-cache + outbox/pubsub side services.
+vi.mock("@src/services/sdk/namespaces/collections/lazy-services", () => ({
+  getResponseCacheLazy: vi.fn().mockResolvedValue({
+    invalidateCollection: vi.fn().mockResolvedValue(undefined),
+    invalidateAll: vi.fn().mockResolvedValue(undefined),
+  }),
+  getOutboxLazy: vi.fn(),
+  getPubSubLazy: vi.fn(),
+  getWorkflowServiceLazy: vi.fn(),
 }));
 
 describe("collections post-write invalidation", () => {
   beforeEach(() => {
+    vi.mocked(cacheService.clearByTags).mockClear();
     vi.mocked(cacheService.clearByPattern).mockClear();
   });
 
   async function flushInvalidation(): Promise<void> {
     await vi.waitFor(() => {
-      expect(cacheService.clearByPattern).toHaveBeenCalled();
+      expect(cacheService.clearByTags).toHaveBeenCalled();
     });
   }
 
-  it("does not purge cms:content_structure on entry mutations", async () => {
+  it("clears collection + count tags, never schema/content_structure", async () => {
     invalidateCache({ _id: "Posts" } as any, "tenant-a" as any);
     await flushInvalidation();
 
+    const tags = vi.mocked(cacheService.clearByTags).mock.calls.flatMap((c) => c[0] as string[]);
+    // Collection-wide list + count caches are cleared by tag (O(#matched)).
+    expect(tags).toContain("collection:Posts");
+    expect(tags).toContain("count:Posts");
+    // Must NOT evict schema models / content structure.
+    expect(tags.some((t) => t.includes("content_structure"))).toBe(false);
+    expect(tags.some((t) => t.startsWith("schema"))).toBe(false);
+    // No O(#docs) pattern scan for the collection namespace on the write path.
     const patterns = vi.mocked(cacheService.clearByPattern).mock.calls.map((c) => String(c[0]));
-    expect(patterns.some((p) => p.includes("content_structure"))).toBe(false);
-    expect(patterns).toContain("collection:Posts:");
-    expect(patterns).toContain("/api/collections/Posts*");
+    expect(patterns.some((p) => p.startsWith("collection:"))).toBe(false);
   });
 
-  it("adds a lowercase API pattern only when the schema id is mixed-case", async () => {
-    invalidateCache({ _id: "posts" } as any, "tenant-a" as any);
+  it("surgically clears ONLY the written doc's per-id tag", async () => {
+    invalidateCache({ _id: "Posts" } as any, "tenant-a" as any, { writtenId: "abc-123" });
     await flushInvalidation();
 
-    const patterns = vi.mocked(cacheService.clearByPattern).mock.calls.map((c) => String(c[0]));
-    expect(patterns).toContain("/api/collections/posts*");
-    expect(patterns.filter((p) => p.startsWith("/api/collections/")).length).toBe(1);
+    const tags = vi.mocked(cacheService.clearByTags).mock.calls.flatMap((c) => c[0] as string[]);
+    expect(tags).toContain("doc:Posts:abc-123");
+    // Exactly one doc tag — writes never clear other documents' per-id caches.
+    expect(tags.filter((t) => t.startsWith("doc:")).length).toBe(1);
+  });
+
+  it("clears every written doc tag for a coalesced bulk write", async () => {
+    invalidateCache({ _id: "Posts" } as any, "tenant-a" as any, {
+      writtenIds: ["a", "b", "c"],
+    });
+    await flushInvalidation();
+
+    const tags = vi.mocked(cacheService.clearByTags).mock.calls.flatMap((c) => c[0] as string[]);
+    for (const id of ["a", "b", "c"]) expect(tags).toContain(`doc:Posts:${id}`);
   });
 });


### PR DESCRIPTION
## Description

Create / update / mixed request throughput collapsed ~5× once a collection held ~10k documents — **identically across all four database engines** (SQLite, PostgreSQL, MariaDB, MongoDB). Because every engine degraded to the *same* number, the bottleneck was shared JavaScript, not any adapter's SQL.

Every write did an **O(number-of-cached-documents) scan** of the in-memory L1 cache (`max: 500_000`, which never evicts at 10k). Three per-document cache layers each accumulated ~one entry per doc and were cleared collection-wide on every write:

1. **SDK per-id cache** — keyed `…global:collection:C:<id>` (namespace bucket `tenant:default:global`) but cleared with pattern `collection:C:*` (bucket `tenant:default:collection`); the buckets never matched, so `prefixMap.get()` missed and the clear fell into a full `l1.keys()` scan.
2. **Turbo `res:` response cache** — the interior-wildcard pattern `res:*C*` never matches yet scans the whole `res:` namespace bucket.
3. **API dispatch cache** — `/api/collections/C*` matched and deleted every per-id entry.

MongoDB additionally passed a wildcard tenant to `invalidateQueryCache`, taking a direct full-L1 scan ×5 per write — which is why it was the worst-hit engine.

**Fix** — switch collection-content invalidation from O(N) pattern scans to **tag-based clears** (O(#matched)):

- Per-id reads are tagged `doc:<coll>:<id>`; list/count reads are tagged `collection:<coll>`.
- A write clears `collection:<coll>` (a handful of list/count keys) **plus only the written document's** `doc:<coll>:<id>` — the written id(s) are threaded through `schedulePostWrite` and the bulk update/delete paths.
- `base-adapter.invalidateQueryCache` normalizes the tenant (`|| "default"`) so writes never take the wildcard full-scan branch, and clears by tag.
- High-cardinality per-entity GET responses stay in the bounded turbo L1 only (never the shared 500k L1), via `isPerEntityApiPath` / `skipSharedL1`.
- A scan-guard caps any residual pattern scan on the hot path, and L2-hydrated keys register in the namespace bucket index.

**Results** (`BENCH_DOCS=10000`, concurrent 8c, create / update RPS):

| DB | create before → after | update before → after |
|---|---|---|
| SQLite | 781 → **2662** | 781 → **2758** |
| PostgreSQL | 632 → **1722** | 669 → **2081** |
| MariaDB | 643 → **2274** | 608 → **2129** |
| MongoDB | 414 → **2283** | 366 → **1792** |

2.7–5.5× on create/update; write p95 ~17–34 ms → ~5–6 ms. Write throughput is now doc-count-independent (10k writes exceed the pre-fix 500-doc numbers).

## Type of Change

- [x] Bug fix (performance regression — throughput cliff at scale)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

No API/behavior change beyond invalidation timing; backward compatible.

## Related Issues

Reported via the maintainer's competitive benchmark (SveltyCMS vs Payload/Directus/Strapi) — write throughput collapse at ~10k documents. No public issue number.

## Testing

Verified end-to-end against real databases via `tests/docker-compose.yml` (MongoDB, MariaDB, PostgreSQL + Redis) and embedded SQLite, at `BENCH_DOCS=10000`:

- **Tested on SQLite** — create 781 → 2662, update 781 → 2758 RPS
- **Tested on PostgreSQL** — create 632 → 1722, update 669 → 2081 RPS
- **Tested on MariaDB** — create 643 → 2274, update 608 → 2129 RPS
- **Tested on MongoDB** — create 414 → 2283, update 366 → 1792 RPS
- **Added unit tests** — tag-scoping in `cache-service.test.ts` (a collection-wide clear must NOT touch per-id doc caches; a per-doc clear touches only the written doc); `collections-post-write.test.ts` updated to the tag contract + bulk id coverage.
- **Regression guard** — opt-in `BENCH_SCALE_GUARD=1` on the competitive replica asserts write/read RPS ratio ≥ 0.4 (post-fix ~0.6–0.8, pre-fix ~0.24) so this cliff can't silently return.
- **528 existing unit tests pass** across the touched areas; `bun run check` (format + lint) clean; production build + pre-push SQLite integration pass.

Reproduce:

```bash
docker compose -f tests/docker-compose.yml --profile mongodb --profile mariadb --profile postgresql --profile redis up -d --wait
bun install && bun run paraglide && bun run build
DB_TYPE=<db> BENCH_DOCS=10000 RATE_LIMIT_MAX_REQUESTS=100000000 \
  bun test tests/benchmarks/competitive-workload-replica.test.ts --timeout 300000
```

## Known limitations / follow-ups

Pre-existing weak-invalidation behaviors in the response/L2 layer, **unchanged in outcome** by this PR (bounded by TTL) — flagged for a focused follow-up rather than expanding this diff into the hot request pipeline:

- Shared response/dispatch cache for content GETs is invalidated by TTL (≤300s) + same-node localL1, not immediately across the shared L1 (the removed `/api/*` pattern clears were name/id-mismatched for UUID-id collections). Follow-up: tag response-cache entries by collection.
- L2 (Redis) hydration re-registers the namespace bucket but not tags (tags aren't persisted in the L2 value), so a content entry hydrated from Redis is invalidated by TTL rather than the tag clear on that node. Follow-up: persist tags through L2.
- Count cache remains TTL-bounded (≤30s) on SQL adapters (pre-existing; keyed by physical table name).

## Checklist

- [x] Code follows the project's code style (`bun run check` / oxlint + oxfmt clean)
- [x] Self-review of code completed (extra-high-effort multi-angle review; one finding — empty-string-tenant `??` → `||` — fixed inline)
- [x] Comments added to complex code sections (invalidation, scan-guard, per-entity bounding)
- [x] No new warnings or errors
- [x] Tests added/updated and passing (unit + 4-DB benchmark + opt-in regression guard)
- [x] Database-agnostic pattern maintained (fix is entirely in shared adapter-agnostic code)
- [x] PR description clearly explains changes
- [ ] Documentation updated — N/A (internal performance fix, no user-facing API change)
